### PR TITLE
sample-heap: initial working implementation

### DIFF
--- a/deps/nan/.dntrc
+++ b/deps/nan/.dntrc
@@ -1,0 +1,30 @@
+## DNT config file
+## see https://github.com/rvagg/dnt
+
+NODE_VERSIONS="\
+  master   \
+  v0.11.13 \
+  v0.10.30 \
+  v0.10.29 \
+  v0.10.28 \
+  v0.10.26 \
+  v0.10.25 \
+  v0.10.24 \
+  v0.10.23 \
+  v0.10.22 \
+  v0.10.21 \
+  v0.10.20 \
+  v0.10.19 \
+  v0.8.28  \
+  v0.8.27  \
+  v0.8.26  \
+  v0.8.24  \
+"
+OUTPUT_PREFIX="nan-"
+TEST_CMD="                                                                        \
+  cd /dnt/ &&                                                                     \
+  npm install &&                                                                  \
+  node_modules/.bin/node-gyp --nodedir /usr/src/node/ rebuild --directory test && \
+  node_modules/.bin/tap --gc test/js/*-test.js                                    \
+"
+

--- a/deps/nan/.gitignore
+++ b/deps/nan/.gitignore
@@ -1,0 +1,2 @@
+build/
+node_modules/

--- a/deps/nan/.npmignore
+++ b/deps/nan/.npmignore
@@ -1,0 +1,6 @@
+test/
+examples/
+.travis.yml
+.npmignore
+Makefile
+cpplint.py

--- a/deps/nan/.travis.yml
+++ b/deps/nan/.travis.yml
@@ -1,0 +1,31 @@
+os:
+  - linux
+  - osx
+sudo: false
+language: cpp
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - g++-4.8
+env:
+  matrix:
+  - TRAVIS_NODE_VERSION="0.8"
+  - TRAVIS_NODE_VERSION="0.10"
+  - TRAVIS_NODE_VERSION="0.12"
+  - TRAVIS_NODE_VERSION="iojs-3"
+  - TRAVIS_NODE_VERSION="4"
+notifications:
+  email:
+    - rod@vagg.org
+install:
+  - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
+  - if [[ $TRAVIS_NODE_VERSION == "0.8" ]]; then npm install npm@2 && node_modules/.bin/npm install npm; else npm install npm; fi
+  - mv node_modules npm
+  - npm/.bin/npm --version
+  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export CXX=g++-4.8; fi
+  - $CXX --version
+  - npm/.bin/npm install
+  - node_modules/.bin/node-gyp rebuild --directory test
+script: node_modules/.bin/tap --gc test/js/*-test.js

--- a/deps/nan/CHANGELOG.md
+++ b/deps/nan/CHANGELOG.md
@@ -1,0 +1,384 @@
+# NAN ChangeLog
+
+**Version 2.1.0: current Node 4.1.2, Node 12: 0.12.7, Node 10: 0.10.40, iojs: 3.3.1**
+
+### 2.1.0 Oct 8 2015
+
+  - Deprecation: Deprecate NanErrnoException in favor of ErrnoException 0af1ca4cf8b3f0f65ed31bc63a663ab3319da55c
+  - Feature: added helper class for accessing contents of typedarrays 17b51294c801e534479d5463697a73462d0ca555
+  - Feature: [Maybe types] Add MakeMaybe(...) 48d7b53d9702b0c7a060e69ea10fea8fb48d814d
+  - Feature: new: allow utf16 string with length 66ac6e65c8ab9394ef588adfc59131b3b9d8347b
+  - Feature: Introduce SetCallHandler and SetCallAsFunctionHandler 7764a9a115d60ba10dc24d86feb0fbc9b4f75537
+  - Bugfix: Enable creating Locals from Globals under Node 0.10. 9bf9b8b190821af889790fdc18ace57257e4f9ff
+  - Bugfix: Fix issue #462 where PropertyCallbackInfo data is not stored safely. 55f50adedd543098526c7b9f4fffd607d3f9861f
+
+### 2.0.9 Sep 8 2015
+
+  - Bugfix: EscapableHandleScope in Nan::NewBuffer for Node 0.8 and 0.10 b1654d7
+
+### 2.0.8 Aug 28 2015
+
+  - Work around duplicate linking bug in clang 11902da
+
+### 2.0.7 Aug 26 2015
+
+  - Build: Repackage
+
+### 2.0.6 Aug 26 2015
+
+  - Bugfix: Properly handle null callback in FunctionTemplate factory 6e99cb1
+  - Bugfix: Remove unused static std::map instances 525bddc
+  - Bugfix: Make better use of maybe versions of APIs bfba85b
+  - Bugfix: Fix shadowing issues with handle in ObjectWrap 0a9072d
+
+### 2.0.5 Aug 10 2015
+
+  - Bugfix: Reimplement weak callback in ObjectWrap 98d38c1
+  - Bugfix: Make sure callback classes are not assignable, copyable or movable 81f9b1d
+
+### 2.0.4 Aug 6 2015
+
+  - Build: Repackage
+
+### 2.0.3 Aug 6 2015
+
+  - Bugfix: Don't use clang++ / g++ syntax extension. 231450e
+
+### 2.0.2 Aug 6 2015
+
+  - Build: Repackage
+
+### 2.0.1 Aug 6 2015
+
+  - Bugfix: Add workaround for missing REPLACE_INVALID_UTF8 60d6687
+  - Bugfix: Reimplement ObjectWrap from scratch to prevent memory leaks 6484601
+  - Bugfix: Fix Persistent leak in FunctionCallbackInfo and PropertyCallbackInfo 641ef5f
+  - Bugfix: Add missing overload for Nan::NewInstance that takes argc/argv 29450ed
+
+### 2.0.0 Jul 31 2015
+
+  - Change: Renamed identifiers with leading underscores	b5932b4
+  - Change: Replaced NanObjectWrapHandle with class NanObjectWrap	464f1e1
+  - Change: Replace NanScope and NanEscpableScope macros with classes	47751c4
+  - Change: Rename NanNewBufferHandle to NanNewBuffer	6745f99
+  - Change: Rename NanBufferUse to NanNewBuffer	3e8b0a5
+  - Change: Rename NanNewBuffer to NanCopyBuffer	d6af78d
+  - Change: Remove Nan prefix from all names	72d1f67
+  - Change: Update Buffer API for new upstream changes	d5d3291
+  - Change: Rename Scope and EscapableScope to HandleScope and EscapableHandleScope	21a7a6a
+  - Change: Get rid of Handles	 e6c0daf
+  - Feature: Support io.js 3 with V8 4.4
+  - Feature: Introduce NanPersistent	7fed696
+  - Feature: Introduce NanGlobal	4408da1
+  - Feature: Added NanTryCatch	10f1ca4
+  - Feature: Update for V8 v4.3	4b6404a
+  - Feature: Introduce NanNewOneByteString	c543d32
+  - Feature: Introduce namespace Nan	67ed1b1
+  - Removal: Remove NanLocker and NanUnlocker	dd6e401
+  - Removal: Remove string converters, except NanUtf8String, which now follows the node implementation b5d00a9
+  - Removal: Remove NanReturn* macros	d90a25c
+  - Removal: Remove HasInstance	e8f84fe
+
+
+### 1.9.0 Jul 31 2015
+
+  - Feature: Added `NanFatalException` 81d4a2c
+  - Feature: Added more error types 4265f06
+  - Feature: Added dereference and function call operators to NanCallback c4b2ed0
+  - Feature: Added indexed GetFromPersistent and SaveToPersistent edd510c
+  - Feature: Added more overloads of SaveToPersistent and GetFromPersistent 8b1cef6
+  - Feature: Added NanErrnoException dd87d9e
+  - Correctness: Prevent assign, copy, and move for classes that do not support it 1f55c59, 4b808cb, c96d9b2, fba4a29, 3357130
+  - Deprecation: Deprecate `NanGetPointerSafe` and `NanSetPointerSafe` 81d4a2c
+  - Deprecation: Deprecate `NanBooleanOptionValue` and `NanUInt32OptionValue` 0ad254b
+
+### 1.8.4 Apr 26 2015
+
+  - Build: Repackage
+
+### 1.8.3 Apr 26 2015
+
+  - Bugfix: Include missing header 1af8648
+
+### 1.8.2 Apr 23 2015
+
+  - Build: Repackage
+
+### 1.8.1 Apr 23 2015
+
+  - Bugfix: NanObjectWrapHandle should take a pointer 155f1d3
+
+### 1.8.0 Apr 23 2015
+
+  - Feature: Allow primitives with NanReturnValue 2e4475e
+  - Feature: Added comparison operators to NanCallback 55b075e
+  - Feature: Backport thread local storage 15bb7fa
+  - Removal: Remove support for signatures with arguments 8a2069d
+  - Correcteness: Replaced NanObjectWrapHandle macro with function 0bc6d59
+
+### 1.7.0 Feb 28 2015
+
+  - Feature: Made NanCallback::Call accept optional target 8d54da7
+  - Feature: Support atom-shell 0.21 0b7f1bb
+
+### 1.6.2 Feb 6 2015
+
+  - Bugfix: NanEncode: fix argument type for node::Encode on io.js 2be8639
+
+### 1.6.1 Jan 23 2015
+
+  - Build: version bump
+
+### 1.5.3 Jan 23 2015
+
+  - Build: repackage
+
+### 1.6.0 Jan 23 2015
+
+ - Deprecated `NanNewContextHandle` in favor of `NanNew<Context>` 49259af
+ - Support utility functions moved in newer v8 versions (Node 0.11.15, io.js 1.0) a0aa179
+ - Added `NanEncode`, `NanDecodeBytes` and `NanDecodeWrite` 75e6fb9
+
+### 1.5.2 Jan 23 2015
+
+  - Bugfix: Fix non-inline definition build error with clang++ 21d96a1, 60fadd4
+  - Bugfix: Readded missing String constructors 18d828f
+  - Bugfix: Add overload handling NanNew<FunctionTemplate>(..) 5ef813b
+  - Bugfix: Fix uv_work_cb versioning 997e4ae
+  - Bugfix: Add function factory and test 4eca89c
+  - Bugfix: Add object template factory and test cdcb951
+  - Correctness: Lifted an io.js related typedef c9490be
+  - Correctness: Make explicit downcasts of String lengths 00074e6
+  - Windows: Limit the scope of disabled warning C4530 83d7deb
+
+### 1.5.1 Jan 15 2015
+
+  - Build: version bump
+
+### 1.4.3 Jan 15 2015
+
+  - Build: version bump
+
+### 1.4.2 Jan 15 2015
+
+  - Feature: Support io.js 0dbc5e8
+
+### 1.5.0 Jan 14 2015
+
+ - Feature: Support io.js b003843
+ - Correctness: Improved NanNew internals 9cd4f6a
+ - Feature: Implement progress to NanAsyncWorker 8d6a160
+
+### 1.4.1 Nov 8 2014
+
+ - Bugfix: Handle DEBUG definition correctly
+ - Bugfix: Accept int as Boolean
+
+### 1.4.0 Nov 1 2014
+
+ - Feature: Added NAN_GC_CALLBACK 6a5c245
+ - Performance: Removed unnecessary local handle creation 18a7243, 41fe2f8
+ - Correctness: Added constness to references in NanHasInstance 02c61cd
+ - Warnings: Fixed spurious warnings from -Wundef and -Wshadow, 541b122, 99d8cb6
+ - Windoze: Shut Visual Studio up when compiling 8d558c1
+ - License: Switch to plain MIT from custom hacked MIT license 11de983
+ - Build: Added test target to Makefile e232e46
+ - Performance: Removed superfluous scope in NanAsyncWorker f4b7821
+ - Sugar/Feature: Added NanReturnThis() and NanReturnHolder() shorthands 237a5ff, d697208
+ - Feature: Added suitable overload of NanNew for v8::Integer::NewFromUnsigned b27b450
+
+### 1.3.0 Aug 2 2014
+
+ - Added NanNew<v8::String, std::string>(std::string)
+ - Added NanNew<v8::String, std::string&>(std::string&)
+ - Added NanAsciiString helper class
+ - Added NanUtf8String helper class
+ - Added NanUcs2String helper class
+ - Deprecated NanRawString()
+ - Deprecated NanCString()
+ - Added NanGetIsolateData(v8::Isolate *isolate)
+ - Added NanMakeCallback(v8::Handle<v8::Object> target, v8::Handle<v8::Function> func, int argc, v8::Handle<v8::Value>* argv)
+ - Added NanMakeCallback(v8::Handle<v8::Object> target, v8::Handle<v8::String> symbol, int argc, v8::Handle<v8::Value>* argv)
+ - Added NanMakeCallback(v8::Handle<v8::Object> target, const char* method, int argc, v8::Handle<v8::Value>* argv)
+ - Added NanSetTemplate(v8::Handle<v8::Template> templ, v8::Handle<v8::String> name , v8::Handle<v8::Data> value, v8::PropertyAttribute attributes)
+ - Added NanSetPrototypeTemplate(v8::Local<v8::FunctionTemplate> templ, v8::Handle<v8::String> name, v8::Handle<v8::Data> value, v8::PropertyAttribute attributes)
+ - Added NanSetInstanceTemplate(v8::Local<v8::FunctionTemplate> templ, const char *name, v8::Handle<v8::Data> value)
+ - Added NanSetInstanceTemplate(v8::Local<v8::FunctionTemplate> templ, v8::Handle<v8::String> name, v8::Handle<v8::Data> value, v8::PropertyAttribute attributes)
+
+### 1.2.0 Jun 5 2014
+
+ - Add NanSetPrototypeTemplate
+ - Changed NAN_WEAK_CALLBACK internals, switched _NanWeakCallbackData to class,
+     introduced _NanWeakCallbackDispatcher
+ - Removed -Wno-unused-local-typedefs from test builds
+ - Made test builds Windows compatible ('Sleep()')
+
+### 1.1.2 May 28 2014
+
+ - Release to fix more stuff-ups in 1.1.1
+
+### 1.1.1 May 28 2014
+
+ - Release to fix version mismatch in nan.h and lack of changelog entry for 1.1.0
+
+### 1.1.0 May 25 2014
+
+ - Remove nan_isolate, use v8::Isolate::GetCurrent() internally instead
+ - Additional explicit overloads for NanNew(): (char*,int), (uint8_t*[,int]),
+     (uint16_t*[,int), double, int, unsigned int, bool, v8::String::ExternalStringResource*,
+     v8::String::ExternalAsciiStringResource*
+ - Deprecate NanSymbol()
+ - Added SetErrorMessage() and ErrorMessage() to NanAsyncWorker
+
+### 1.0.0 May 4 2014
+
+ - Heavy API changes for V8 3.25 / Node 0.11.13
+ - Use cpplint.py
+ - Removed NanInitPersistent
+ - Removed NanPersistentToLocal
+ - Removed NanFromV8String
+ - Removed NanMakeWeak
+ - Removed NanNewLocal
+ - Removed NAN_WEAK_CALLBACK_OBJECT
+ - Removed NAN_WEAK_CALLBACK_DATA
+ - Introduce NanNew, replaces NanNewLocal, NanPersistentToLocal, adds many overloaded typed versions
+ - Introduce NanUndefined, NanNull, NanTrue and NanFalse
+ - Introduce NanEscapableScope and NanEscapeScope
+ - Introduce NanMakeWeakPersistent (requires a special callback to work on both old and new node)
+ - Introduce NanMakeCallback for node::MakeCallback
+ - Introduce NanSetTemplate
+ - Introduce NanGetCurrentContext
+ - Introduce NanCompileScript and NanRunScript
+ - Introduce NanAdjustExternalMemory
+ - Introduce NanAddGCEpilogueCallback, NanAddGCPrologueCallback, NanRemoveGCEpilogueCallback, NanRemoveGCPrologueCallback
+ - Introduce NanGetHeapStatistics
+ - Rename NanAsyncWorker#SavePersistent() to SaveToPersistent()
+
+### 0.8.0 Jan 9 2014
+
+ - NanDispose -> NanDisposePersistent, deprecate NanDispose
+ - Extract _NAN_*_RETURN_TYPE, pull up NAN_*()
+
+### 0.7.1 Jan 9 2014
+
+ - Fixes to work against debug builds of Node
+ - Safer NanPersistentToLocal (avoid reinterpret_cast)
+ - Speed up common NanRawString case by only extracting flattened string when necessary
+
+### 0.7.0 Dec 17 2013
+
+ - New no-arg form of NanCallback() constructor.
+ - NanCallback#Call takes Handle rather than Local
+ - Removed deprecated NanCallback#Run method, use NanCallback#Call instead
+ - Split off _NAN_*_ARGS_TYPE from _NAN_*_ARGS
+ - Restore (unofficial) Node 0.6 compatibility at NanCallback#Call()
+ - Introduce NanRawString() for char* (or appropriate void*) from v8::String
+     (replacement for NanFromV8String)
+ - Introduce NanCString() for null-terminated char* from v8::String
+
+### 0.6.0 Nov 21 2013
+
+ - Introduce NanNewLocal<T>(v8::Handle<T> value) for use in place of
+     v8::Local<T>::New(...) since v8 started requiring isolate in Node 0.11.9
+
+### 0.5.2 Nov 16 2013
+
+ - Convert SavePersistent and GetFromPersistent in NanAsyncWorker from protected and public
+
+### 0.5.1 Nov 12 2013
+
+ - Use node::MakeCallback() instead of direct v8::Function::Call()
+
+### 0.5.0 Nov 11 2013
+
+ - Added @TooTallNate as collaborator
+ - New, much simpler, "include_dirs" for binding.gyp
+ - Added full range of NAN_INDEX_* macros to match NAN_PROPERTY_* macros
+
+### 0.4.4 Nov 2 2013
+
+ - Isolate argument from v8::Persistent::MakeWeak removed for 0.11.8+
+
+### 0.4.3 Nov 2 2013
+
+ - Include node_object_wrap.h, removed from node.h for Node 0.11.8.
+
+### 0.4.2 Nov 2 2013
+
+ - Handle deprecation of v8::Persistent::Dispose(v8::Isolate* isolate)) for
+     Node 0.11.8 release.
+
+### 0.4.1 Sep 16 2013
+
+ - Added explicit `#include <uv.h>` as it was removed from node.h for v0.11.8
+
+### 0.4.0 Sep 2 2013
+
+ - Added NAN_INLINE and NAN_DEPRECATED and made use of them
+ - Added NanError, NanTypeError and NanRangeError
+ - Cleaned up code
+
+### 0.3.2 Aug 30 2013
+
+ - Fix missing scope declaration in GetFromPersistent() and SaveToPersistent
+     in NanAsyncWorker
+
+### 0.3.1 Aug 20 2013
+
+ - fix "not all control paths return a value" compile warning on some platforms
+
+### 0.3.0 Aug 19 2013
+
+ - Made NAN work with NPM
+ - Lots of fixes to NanFromV8String, pulling in features from new Node core
+ - Changed node::encoding to Nan::Encoding in NanFromV8String to unify the API
+ - Added optional error number argument for NanThrowError()
+ - Added NanInitPersistent()
+ - Added NanReturnNull() and NanReturnEmptyString()
+ - Added NanLocker and NanUnlocker
+ - Added missing scopes
+ - Made sure to clear disposed Persistent handles
+ - Changed NanAsyncWorker to allocate error messages on the heap
+ - Changed NanThrowError(Local<Value>) to NanThrowError(Handle<Value>)
+ - Fixed leak in NanAsyncWorker when errmsg is used
+
+### 0.2.2 Aug 5 2013
+
+ - Fixed usage of undefined variable with node::BASE64 in NanFromV8String()
+
+### 0.2.1 Aug 5 2013
+
+ - Fixed 0.8 breakage, node::BUFFER encoding type not available in 0.8 for
+     NanFromV8String()
+
+### 0.2.0 Aug 5 2013
+
+ - Added NAN_PROPERTY_GETTER, NAN_PROPERTY_SETTER, NAN_PROPERTY_ENUMERATOR,
+     NAN_PROPERTY_DELETER, NAN_PROPERTY_QUERY
+ - Extracted _NAN_METHOD_ARGS, _NAN_GETTER_ARGS, _NAN_SETTER_ARGS,
+     _NAN_PROPERTY_GETTER_ARGS, _NAN_PROPERTY_SETTER_ARGS,
+     _NAN_PROPERTY_ENUMERATOR_ARGS, _NAN_PROPERTY_DELETER_ARGS,
+     _NAN_PROPERTY_QUERY_ARGS
+ - Added NanGetInternalFieldPointer, NanSetInternalFieldPointer
+ - Added NAN_WEAK_CALLBACK, NAN_WEAK_CALLBACK_OBJECT,
+     NAN_WEAK_CALLBACK_DATA, NanMakeWeak
+ - Renamed THROW_ERROR to _NAN_THROW_ERROR
+ - Added NanNewBufferHandle(char*, size_t, node::smalloc::FreeCallback, void*)
+ - Added NanBufferUse(char*, uint32_t)
+ - Added NanNewContextHandle(v8::ExtensionConfiguration*,
+       v8::Handle<v8::ObjectTemplate>, v8::Handle<v8::Value>)
+ - Fixed broken NanCallback#GetFunction()
+ - Added optional encoding and size arguments to NanFromV8String()
+ - Added NanGetPointerSafe() and NanSetPointerSafe()
+ - Added initial test suite (to be expanded)
+ - Allow NanUInt32OptionValue to convert any Number object
+
+### 0.1.0 Jul 21 2013
+
+ - Added `NAN_GETTER`, `NAN_SETTER`
+ - Added `NanThrowError` with single Local<Value> argument
+ - Added `NanNewBufferHandle` with single uint32_t argument
+ - Added `NanHasInstance(Persistent<FunctionTemplate>&, Handle<Value>)`
+ - Added `Local<Function> NanCallback#GetFunction()`
+ - Added `NanCallback#Call(int, Local<Value>[])`
+ - Deprecated `NanCallback#Run(int, Local<Value>[])` in favour of Call

--- a/deps/nan/LICENSE.md
+++ b/deps/nan/LICENSE.md
@@ -1,0 +1,13 @@
+The MIT License (MIT)
+=====================
+
+Copyright (c) 2015 NAN contributors
+-----------------------------------
+
+*NAN contributors listed at <https://github.com/nodejs/nan#contributors>*
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/deps/nan/Makefile
+++ b/deps/nan/Makefile
@@ -1,0 +1,102 @@
+TOPLEVEL ?= $(dir $(lastword $(MAKEFILE_LIST)))
+CPPLINT ?= $(TOPLEVEL)/cpplint.py
+PYTHON ?= python
+BUILDTYPE ?= Release
+MODULES = symbols strings
+SOURCES = $(MODULES:%=test/cpp/%.cpp)
+ADDONS = $(MODULES:%=test/build/$(BUILDTYPE)/%.node)
+
+LINT_SOURCES = \
+	examples/async_pi_estimate/addon.cc \
+	examples/async_pi_estimate/async.cc \
+	examples/async_pi_estimate/async.h \
+	examples/async_pi_estimate/pi_est.cc \
+	examples/async_pi_estimate/pi_est.h \
+	examples/async_pi_estimate/sync.cc \
+	examples/async_pi_estimate/sync.h \
+	nan.h \
+	nan_callbacks.h \
+	nan_callbacks_12_inl.h \
+	nan_callbacks_pre_12_inl.h \
+	nan_converters.h \
+	nan_converters_43_inl.h \
+	nan_converters_pre_43_inl.h \
+	nan_implementation_12_inl.h \
+	nan_implementation_pre_12_inl.h \
+	nan_maybe_43_inl.h \
+	nan_maybe_pre_43_inl.h \
+	nan_new.h \
+	nan_object_wrap.h \
+	nan_persistent_12_inl.h \
+	nan_persistent_pre_12_inl.h \
+	nan_string_bytes.h \
+	nan_weak.h \
+	test/cpp/accessors.cpp \
+	test/cpp/accessors2.cpp \
+	test/cpp/asyncworker.cpp \
+	test/cpp/asyncprogressworker.cpp \
+	test/cpp/asyncworkererror.cpp \
+	test/cpp/buffer.cpp \
+	test/cpp/bufferworkerpersistent.cpp \
+	test/cpp/error.cpp \
+	test/cpp/gc.cpp \
+	test/cpp/indexedinterceptors.cpp \
+	test/cpp/isolatedata.cpp \
+	test/cpp/makecallback.cpp \
+	test/cpp/morenews.cpp \
+	test/cpp/converters.cpp \
+	test/cpp/isolatedata.cpp \
+	test/cpp/makecallback.cpp \
+	test/cpp/morenews.cpp \
+	test/cpp/multifile1.cpp \
+	test/cpp/multifile2.cpp \
+	test/cpp/multifile2.h \
+	test/cpp/namedinterceptors.cpp \
+	test/cpp/nancallback.cpp \
+	test/cpp/nannew.cpp \
+	test/cpp/news.cpp \
+	test/cpp/objectwraphandle.cpp \
+	test/cpp/persistent.cpp \
+	test/cpp/returnemptystring.cpp \
+	test/cpp/returnnull.cpp \
+	test/cpp/returnundefined.cpp \
+	test/cpp/returnvalue.cpp \
+	test/cpp/setcallhandler.cpp \
+	test/cpp/settemplate.cpp \
+	test/cpp/strings.cpp \
+	test/cpp/symbols.cpp \
+	test/cpp/threadlocal.cpp \
+	test/cpp/trycatch.cpp \
+	test/cpp/weak.cpp \
+	test/cpp/weak2.cpp \
+	test/cpp/wrappedobjectfactory.cpp \
+	node_modules/node-gyp/gyp/data/win/large-pdb-shim.cc
+
+FILTER = -whitespace/parens
+
+.PHONY: lint
+
+lint:
+	cd $(TOPLEVEL) && $(PYTHON) $(CPPLINT) --filter=$(FILTER) $(LINT_SOURCES)
+
+test: $(ADDONS)
+	npm test
+
+forcetest:
+	cd test/ && node-gyp rebuild && cd ..
+	npm test
+
+docs: README.md doc/.build.sh doc/asyncworker.md doc/buffers.md doc/callback.md \
+		doc/converters.md doc/errors.md doc/maybe_types.md doc/methods.md doc/new.md \
+		doc/node_misc.md doc/persistent.md doc/scopes.md doc/script.md doc/string_bytes.md \
+		doc/v8_internals.md doc/v8_misc.md
+	doc/.build.sh
+
+
+$(ADDONS): nan.h nan_new.h nan_implementation_pre_12_inl.h nan_implementation_12_inl.h \
+		nan_callbacks.h nan_callbacks_12_inl.h nan_callbacks_pre_12_inl.h \
+		nan_converters.h nan_converters_43_inl.h nan_converters_pre_43_inl.h \
+		nan_maybe_43_inl.h nan_maybe_pre_43_inl.h \
+		nan_persistent_12_inl.h nan_persistent_pre_12_inl.h nan_weak.h \
+		nan_string_bytes.h test/binding.gyp $(SOURCES)
+	cd test/ && ../node_modules/.bin/node-gyp rebuild

--- a/deps/nan/README.md
+++ b/deps/nan/README.md
@@ -1,0 +1,371 @@
+Native Abstractions for Node.js
+===============================
+
+**A header file filled with macro and utility goodness for making add-on development for Node.js easier across versions 0.8, 0.10, 0.12 and 4.**
+
+***Current version: 2.1.0***
+
+*(See [CHANGELOG.md](https://github.com/nodejs/nan/blob/master/CHANGELOG.md) for complete ChangeLog)*
+
+[![NPM](https://nodei.co/npm/nan.png?downloads=true&downloadRank=true)](https://nodei.co/npm/nan/) [![NPM](https://nodei.co/npm-dl/nan.png?months=6&height=3)](https://nodei.co/npm/nan/)
+
+[![Build Status](https://api.travis-ci.org/nodejs/nan.svg?branch=master)](http://travis-ci.org/nodejs/nan)
+[![Build status](https://ci.appveyor.com/api/projects/status/kh73pbm9dsju7fgh)](https://ci.appveyor.com/project/RodVagg/nan)
+
+Thanks to the crazy changes in V8 (and some in Node core), keeping native addons compiling happily across versions, particularly 0.10 to 0.12 to 4.0, is a minor nightmare. The goal of this project is to store all logic necessary to develop native Node.js addons without having to inspect `NODE_MODULE_VERSION` and get yourself into a macro-tangle.
+
+This project also contains some helper utilities that make addon development a bit more pleasant.
+
+ * **[News & Updates](#news)**
+ * **[Usage](#usage)**
+ * **[Example](#example)**
+ * **[API](#api)**
+ * **[Tests](#tests)**
+ * **[Governance & Contributing](#governance)**
+
+<a name="news"></a>
+## News & Updates
+
+<a name="usage"></a>
+## Usage
+
+Simply add **NAN** as a dependency in the *package.json* of your Node addon:
+
+``` bash
+$ npm install --save nan
+```
+
+Pull in the path to **NAN** in your *binding.gyp* so that you can use `#include <nan.h>` in your *.cpp* files:
+
+``` python
+"include_dirs" : [
+    "<!(node -e \"require('nan')\")"
+]
+```
+
+This works like a `-I<path-to-NAN>` when compiling your addon.
+
+<a name="example"></a>
+## Example
+
+Just getting started with Nan? Refer to a [quick-start **Nan** Boilerplate](https://github.com/fcanas/node-native-boilerplate) for a ready-to-go project that utilizes basic Nan functionality.
+
+For a simpler example, see the **[async pi estimation example](https://github.com/nodejs/nan/tree/master/examples/async_pi_estimate)** in the examples directory for full code and an explanation of what this Monte Carlo Pi estimation example does. Below are just some parts of the full example that illustrate the use of **NAN**.
+
+For another example, see **[nan-example-eol](https://github.com/CodeCharmLtd/nan-example-eol)**. It shows newline detection implemented as a native addon.
+
+<a name="api"></a>
+## API
+
+Additional to the NAN documentation below, please consult:
+
+* [The V8 Getting Started Guide](https://developers.google.com/v8/get_started)
+* [The V8 Embedders Guide](https://developers.google.com/v8/embed)
+* [V8 API Documentation](http://v8docs.nodesource.com/)
+
+<!-- START API -->
+
+### JavaScript-accessible methods
+
+A _template_ is a blueprint for JavaScript functions and objects in a context. You can use a template to wrap C++ functions and data structures within JavaScript objects so that they can be manipulated from JavaScript. See the V8 Embedders Guide section on [Templates](https://developers.google.com/v8/embed#templates) for further information.
+
+In order to expose functionality to JavaScript via a template, you must provide it to V8 in a form that it understands. Across the versions of V8 supported by NAN, JavaScript-accessible method signatures vary widely, NAN fully abstracts method declaration and provides you with an interface that is similar to the most recent V8 API but is backward-compatible with older versions that still use the now-deceased `v8::Argument` type.
+
+* **Method argument types**
+ - <a href="doc/methods.md#api_nan_function_callback_info"><b><code>Nan::FunctionCallbackInfo</code></b></a>
+ - <a href="doc/methods.md#api_nan_property_callback_info"><b><code>Nan::PropertyCallbackInfo</code></b></a>
+ - <a href="doc/methods.md#api_nan_return_value"><b><code>Nan::ReturnValue</code></b></a>
+* **Method declarations**
+ - <a href="doc/methods.md#api_nan_method"><b>Method declaration</b></a>
+ - <a href="doc/methods.md#api_nan_getter"><b>Getter declaration</b></a>
+ - <a href="doc/methods.md#api_nan_setter"><b>Setter declaration</b></a>
+ - <a href="doc/methods.md#api_nan_property_getter"><b>Property getter declaration</b></a>
+ - <a href="doc/methods.md#api_nan_property_setter"><b>Property setter declaration</b></a>
+ - <a href="doc/methods.md#api_nan_property_enumerator"><b>Property enumerator declaration</b></a>
+ - <a href="doc/methods.md#api_nan_property_deleter"><b>Property deleter declaration</b></a>
+ - <a href="doc/methods.md#api_nan_property_query"><b>Property query declaration</b></a>
+ - <a href="doc/methods.md#api_nan_index_getter"><b>Index getter declaration</b></a>
+ - <a href="doc/methods.md#api_nan_index_setter"><b>Index setter declaration</b></a>
+ - <a href="doc/methods.md#api_nan_index_enumerator"><b>Index enumerator declaration</b></a>
+ - <a href="doc/methods.md#api_nan_index_deleter"><b>Index deleter declaration</b></a>
+ - <a href="doc/methods.md#api_nan_index_query"><b>Index query declaration</b></a>
+* Method and template helpers
+ - <a href="doc/methods.md#api_nan_set_method"><b><code>Nan::SetMethod()</code></b></a>
+ - <a href="doc/methods.md#api_nan_set_named_property_handler"><b><code>Nan::SetNamedPropertyHandler()</code></b></a>
+ - <a href="doc/methods.md#api_nan_set_indexed_property_handler"><b><code>Nan::SetIndexedPropertyHandler()</code></b></a>
+ - <a href="doc/methods.md#api_nan_set_prototype_method"><b><code>Nan::SetPrototypeMethod()</code></b></a>
+ - <a href="doc/methods.md#api_nan_set_template"><b><code>Nan::SetTemplate()</code></b></a>
+ - <a href="doc/methods.md#api_nan_set_prototype_template"><b><code>Nan::SetPrototypeTemplate()</code></b></a>
+ - <a href="doc/methods.md#api_nan_set_instance_template"><b><code>Nan::SetInstanceTemplate()</code></b></a>
+ - <a href="doc/methods.md#api_nan_set_call_handler"><b><code>Nan::SetCallHandler()</code></b></a>
+ - <a href="doc/methods.md#api_nan_set_call_as_function_handler"><b><code>Nan::SetCallAsFunctionHandler()</code></b></a>
+
+### Scopes
+
+A _local handle_ is a pointer to an object. All V8 objects are accessed using handles, they are necessary because of the way the V8 garbage collector works.
+
+A handle scope can be thought of as a container for any number of handles. When you've finished with your handles, instead of deleting each one individually you can simply delete their scope.
+
+The creation of `HandleScope` objects is different across the supported versions of V8. Therefore, NAN provides its own implementations that can be used safely across these.
+
+ - <a href="doc/scopes.md#api_nan_handle_scope"><b><code>Nan::HandleScope</code></b></a>
+ - <a href="doc/scopes.md#api_nan_escapable_handle_scope"><b><code>Nan::EscapableHandleScope</code></b></a>
+
+Also see the V8 Embedders Guide section on [Handles and Garbage Collection](https://developers.google.com/v8/embed#handles).
+
+### Persistent references
+
+An object reference that is independent of any `HandleScope` is a _persistent_ reference. Where a `Local` handle only lives as long as the `HandleScope` in which it was allocated, a `Persistent` handle remains valid until it is explicitly disposed.
+
+Due to the evolution of the V8 API, it is necessary for NAN to provide a wrapper implementation of the `Persistent` classes to supply compatibility across the V8 versions supported.
+
+ - <a href="doc/persistent.md#api_nan_persistent_base"><b><code>Nan::PersistentBase & v8::PersistentBase</code></b></a>
+ - <a href="doc/persistent.md#api_nan_non_copyable_persistent_traits"><b><code>Nan::NonCopyablePersistentTraits & v8::NonCopyablePersistentTraits</code></b></a>
+ - <a href="doc/persistent.md#api_nan_copyable_persistent_traits"><b><code>Nan::CopyablePersistentTraits & v8::CopyablePersistentTraits</code></b></a>
+ - <a href="doc/persistent.md#api_nan_persistent"><b><code>Nan::Persistent</code></b></a>
+ - <a href="doc/persistent.md#api_nan_global"><b><code>Nan::Global</code></b></a>
+ - <a href="doc/persistent.md#api_nan_weak_callback_info"><b><code>Nan::WeakCallbackInfo</code></b></a>
+ - <a href="doc/persistent.md#api_nan_weak_callback_type"><b><code>Nan::WeakCallbackType</code></b></a>
+
+Also see the V8 Embedders Guide section on [Handles and Garbage Collection](https://developers.google.com/v8/embed#handles).
+
+### New
+
+NAN provides a `Nan::New()` helper for the creation of new JavaScript objects in a way that's compatible across the supported versions of V8.
+
+ - <a href="doc/new.md#api_nan_new"><b><code>Nan::New()</code></b></a>
+ - <a href="doc/new.md#api_nan_undefined"><b><code>Nan::Undefined()</code></b></a>
+ - <a href="doc/new.md#api_nan_null"><b><code>Nan::Null()</code></b></a>
+ - <a href="doc/new.md#api_nan_true"><b><code>Nan::True()</code></b></a>
+ - <a href="doc/new.md#api_nan_false"><b><code>Nan::False()</code></b></a>
+ - <a href="doc/new.md#api_nan_empty_string"><b><code>Nan::EmptyString()</code></b></a>
+
+
+### Converters
+
+NAN contains functions that convert `v8::Value`s to other `v8::Value` types and native types. Since type conversion is not guaranteed to succeed, they return `Nan::Maybe` types. These converters can be used in place of `value->ToX()` and `value->XValue()` (where `X` is one of the types, e.g. `Boolean`) in a way that provides a consistent interface across V8 versions. Newer versions of V8 use the new `v8::Maybe` and `v8::MaybeLocal` types for these conversions, older versions don't have this functionality so it is provided by NAN.
+
+ - <a href="doc/converters.md#api_nan_to"><b><code>Nan::To()</code></b></a>
+
+### Maybe Types
+
+The `Nan::MaybeLocal` and `Nan::Maybe` types are monads that encapsulate `v8::Local` handles that _may be empty_.
+
+* **Maybe Types**
+  - <a href="doc/maybe_types.md#api_nan_maybe_local"><b><code>Nan::MaybeLocal</code></b></a>
+  - <a href="doc/maybe_types.md#api_nan_maybe"><b><code>Nan::Maybe</code></b></a>
+  - <a href="doc/maybe_types.md#api_nan_nothing"><b><code>Nan::Nothing</code></b></a>
+  - <a href="doc/maybe_types.md#api_nan_just"><b><code>Nan::Just</code></b></a>
+* **Maybe Helpers**
+  - <a href="doc/maybe_types.md#api_nan_to_detail_string"><b><code>Nan::ToDetailString()</code></b></a>
+  - <a href="doc/maybe_types.md#api_nan_to_array_index"><b><code>Nan::ToArrayIndex()</code></b></a>
+  - <a href="doc/maybe_types.md#api_nan_equals"><b><code>Nan::Equals()</code></b></a>
+  - <a href="doc/maybe_types.md#api_nan_new_instance"><b><code>Nan::NewInstance()</code></b></a>
+  - <a href="doc/maybe_types.md#api_nan_get_function"><b><code>Nan::GetFunction()</code></b></a>
+  - <a href="doc/maybe_types.md#api_nan_set"><b><code>Nan::Set()</code></b></a>
+  - <a href="doc/maybe_types.md#api_nan_force_set"><b><code>Nan::ForceSet()</code></b></a>
+  - <a href="doc/maybe_types.md#api_nan_get"><b><code>Nan::Get()</code></b></a>
+  - <a href="doc/maybe_types.md#api_nan_get_property_attribute"><b><code>Nan::GetPropertyAttributes()</code></b></a>
+  - <a href="doc/maybe_types.md#api_nan_has"><b><code>Nan::Has()</code></b></a>
+  - <a href="doc/maybe_types.md#api_nan_delete"><b><code>Nan::Delete()</code></b></a>
+  - <a href="doc/maybe_types.md#api_nan_get_property_names"><b><code>Nan::GetPropertyNames()</code></b></a>
+  - <a href="doc/maybe_types.md#api_nan_get_own_property_names"><b><code>Nan::GetOwnPropertyNames()</code></b></a>
+  - <a href="doc/maybe_types.md#api_nan_set_prototype"><b><code>Nan::SetPrototype()</code></b></a>
+  - <a href="doc/maybe_types.md#api_nan_object_proto_to_string"><b><code>Nan::ObjectProtoToString()</code></b></a>
+  - <a href="doc/maybe_types.md#api_nan_has_own_property"><b><code>Nan::HasOwnProperty()</code></b></a>
+  - <a href="doc/maybe_types.md#api_nan_has_real_named_property"><b><code>Nan::HasRealNamedProperty()</code></b></a>
+  - <a href="doc/maybe_types.md#api_nan_has_real_indexed_property"><b><code>Nan::HasRealIndexedProperty()</code></b></a>
+  - <a href="doc/maybe_types.md#api_nan_has_real_named_callback_property"><b><code>Nan::HasRealNamedCallbackProperty()</code></b></a>
+  - <a href="doc/maybe_types.md#api_nan_get_real_named_property_in_prototype_chain"><b><code>Nan::GetRealNamedPropertyInPrototypeChain()</code></b></a>
+  - <a href="doc/maybe_types.md#api_nan_get_real_named_property"><b><code>Nan::GetRealNamedProperty()</code></b></a>
+  - <a href="doc/maybe_types.md#api_nan_call_as_function"><b><code>Nan::CallAsFunction()</code></b></a>
+  - <a href="doc/maybe_types.md#api_nan_call_as_constructor"><b><code>Nan::CallAsConstructor()</code></b></a>
+  - <a href="doc/maybe_types.md#api_nan_get_source_line"><b><code>Nan::GetSourceLine()</code></b></a>
+  - <a href="doc/maybe_types.md#api_nan_get_line_number"><b><code>Nan::GetLineNumber()</code></b></a>
+  - <a href="doc/maybe_types.md#api_nan_get_start_column"><b><code>Nan::GetStartColumn()</code></b></a>
+  - <a href="doc/maybe_types.md#api_nan_get_end_column"><b><code>Nan::GetEndColumn()</code></b></a>
+  - <a href="doc/maybe_types.md#api_nan_clone_element_at"><b><code>Nan::CloneElementAt()</code></b></a>
+  - <a href="doc/maybe_types.md#api_nan_make_maybe"><b><code>Nan::MakeMaybe()</code></b></a>
+
+### Script
+
+NAN provides a `v8::Script` helpers as the API has changed over the supported versions of V8.
+
+ - <a href="doc/script.md#api_nan_compile_script"><b><code>Nan::CompileScript()</code></b></a>
+ - <a href="doc/script.md#api_nan_run_script"><b><code>Nan::RunScript()</code></b></a>
+
+
+### Errors
+
+NAN includes helpers for creating, throwing and catching Errors as much of this functionality varies across the supported versions of V8 and must be abstracted.
+
+Note that an Error object is simply a specialized form of `v8::Value`.
+
+Also consult the V8 Embedders Guide section on [Exceptions](https://developers.google.com/v8/embed#exceptions) for more information.
+
+ - <a href="doc/errors.md#api_nan_error"><b><code>Nan::Error()</code></b></a>
+ - <a href="doc/errors.md#api_nan_range_error"><b><code>Nan::RangeError()</code></b></a>
+ - <a href="doc/errors.md#api_nan_reference_error"><b><code>Nan::ReferenceError()</code></b></a>
+ - <a href="doc/errors.md#api_nan_syntax_error"><b><code>Nan::SyntaxError()</code></b></a>
+ - <a href="doc/errors.md#api_nan_type_error"><b><code>Nan::TypeError()</code></b></a>
+ - <a href="doc/errors.md#api_nan_throw_error"><b><code>Nan::ThrowError()</code></b></a>
+ - <a href="doc/errors.md#api_nan_throw_range_error"><b><code>Nan::ThrowRangeError()</code></b></a>
+ - <a href="doc/errors.md#api_nan_throw_reference_error"><b><code>Nan::ThrowReferenceError()</code></b></a>
+ - <a href="doc/errors.md#api_nan_throw_syntax_error"><b><code>Nan::ThrowSyntaxError()</code></b></a>
+ - <a href="doc/errors.md#api_nan_throw_type_error"><b><code>Nan::ThrowTypeError()</code></b></a>
+ - <a href="doc/errors.md#api_nan_fatal_exception"><b><code>Nan::FatalException()</code></b></a>
+ - <a href="doc/errors.md#api_nan_errno_exception"><b><code>Nan::ErrnoException()</code></b></a>
+ - <a href="doc/errors.md#api_nan_try_catch"><b><code>Nan::TryCatch</code></b></a>
+
+
+### Buffers
+
+NAN's `node::Buffer` helpers exist as the API has changed across supported Node versions. Use these methods to ensure compatibility.
+
+ - <a href="doc/buffers.md#api_nan_new_buffer"><b><code>Nan::NewBuffer()</code></b></a>
+ - <a href="doc/buffers.md#api_nan_copy_buffer"><b><code>Nan::CopyBuffer()</code></b></a>
+ - <a href="doc/buffers.md#api_nan_free_callback"><b><code>Nan::FreeCallback()</code></b></a>
+
+### Nan::Callback
+
+`Nan::Callback` makes it easier to use `v8::Function` handles as callbacks. A class that wraps a `v8::Function` handle, protecting it from garbage collection and making it particularly useful for storage and use across asynchronous execution.
+
+ - <a href="doc/callback.md#api_nan_callback"><b><code>Nan::Callback</code></b></a>
+
+### Asynchronous work helpers
+
+`Nan::AsyncWorker` and `Nan::AsyncProgressWorker` are helper classes that make working with asynchronous code easier.
+
+ - <a href="doc/asyncworker.md#api_nan_async_worker"><b><code>Nan::AsyncWorker</code></b></a>
+ - <a href="doc/asyncworker.md#api_nan_async_progress_worker"><b><code>Nan::AsyncProgressWorker</code></b></a>
+ - <a href="doc/asyncworker.md#api_nan_async_queue_worker"><b><code>Nan::AsyncQueueWorker</code></b></a>
+
+### Strings & Bytes
+
+Miscellaneous string & byte encoding and decoding functionality provided for compatibility across supported versions of V8 and Node. Implemented by NAN to ensure that all encoding types are supported, even for older versions of Node where they are missing.
+
+ - <a href="doc/string_bytes.md#api_nan_encoding"><b><code>Nan::Encoding</code></b></a>
+ - <a href="doc/string_bytes.md#api_nan_encode"><b><code>Nan::Encode()</code></b></a>
+ - <a href="doc/string_bytes.md#api_nan_decode_bytes"><b><code>Nan::DecodeBytes()</code></b></a>
+ - <a href="doc/string_bytes.md#api_nan_decode_write"><b><code>Nan::DecodeWrite()</code></b></a>
+
+
+### V8 internals
+
+The hooks to access V8 internals—including GC and statistics—are different across the supported versions of V8, therefore NAN provides its own hooks that call the appropriate V8 methods.
+
+ - <a href="doc/v8_internals.md#api_nan_gc_callback"><b><code>NAN_GC_CALLBACK()</code></b></a>
+ - <a href="doc/v8_internals.md#api_nan_add_gc_epilogue_callback"><b><code>Nan::AddGCEpilogueCallback()</code></b></a>
+ - <a href="doc/v8_internals.md#api_nan_remove_gc_epilogue_callback"><b><code>Nan::RemoveGCEpilogueCallback()</code></b></a>
+ - <a href="doc/v8_internals.md#api_nan_add_gc_prologue_callback"><b><code>Nan::AddGCPrologueCallback()</code></b></a>
+ - <a href="doc/v8_internals.md#api_nan_remove_gc_prologue_callback"><b><code>Nan::RemoveGCPrologueCallback()</code></b></a>
+ - <a href="doc/v8_internals.md#api_nan_get_heap_statistics"><b><code>Nan::GetHeapStatistics()</code></b></a>
+ - <a href="doc/v8_internals.md#api_nan_set_counter_function"><b><code>Nan::SetCounterFunction()</code></b></a>
+ - <a href="doc/v8_internals.md#api_nan_set_create_histogram_function"><b><code>Nan::SetCreateHistogramFunction()</code></b></a>
+ - <a href="doc/v8_internals.md#api_nan_set_add_histogram_sample_function"><b><code>Nan::SetAddHistogramSampleFunction()</code></b></a>
+ - <a href="doc/v8_internals.md#api_nan_idle_notification"><b><code>Nan::IdleNotification()</code></b></a>
+ - <a href="doc/v8_internals.md#api_nan_low_memory_notification"><b><code>Nan::LowMemoryNotification()</code></b></a>
+ - <a href="doc/v8_internals.md#api_nan_context_disposed_notification"><b><code>Nan::ContextDisposedNotification()</code></b></a>
+ - <a href="doc/v8_internals.md#api_nan_get_internal_field_pointer"><b><code>Nan::GetInternalFieldPointer()</code></b></a>
+ - <a href="doc/v8_internals.md#api_nan_set_internal_field_pointer"><b><code>Nan::SetInternalFieldPointer()</code></b></a>
+ - <a href="doc/v8_internals.md#api_nan_adjust_external_memory"><b><code>Nan::AdjustExternalMemory()</code></b></a>
+
+
+### Miscellaneous V8 Helpers
+
+ - <a href="doc/v8_misc.md#api_nan_utf8_string"><b><code>Nan::Utf8String</code></b></a>
+ - <a href="doc/v8_misc.md#api_nan_get_current_context"><b><code>Nan::GetCurrentContext()</code></b></a>
+ - <a href="doc/v8_misc.md#api_nan_set_isolate_data"><b><code>Nan::SetIsolateData()</code></b></a>
+ - <a href="doc/v8_misc.md#api_nan_get_isolate_data"><b><code>Nan::GetIsolateData()</code></b></a>
+ - <a href="doc/v8_misc.md#api_nan_typedarray_contents"><b><code>Nan::TypedArrayContents</code></b></a>
+
+
+### Miscellaneous Node Helpers
+
+ - <a href="doc/node_misc.md#api_nan_make_callback"><b><code>Nan::MakeCallback()</code></b></a>
+ - <a href="doc/node_misc.md#api_nan_object_wrap"><b><code>Nan::ObjectWrap</code></b></a>
+ - <a href="doc/node_misc.md#api_nan_module_init"><b><code>NAN_MODULE_INIT()</code></b></a>
+ - <a href="doc/node_misc.md#api_nan_export"><b><code>Nan::Export()</code></b></a>
+
+<!-- END API -->
+
+
+<a name="tests"></a>
+### Tests
+
+To run the NAN tests do:
+
+``` sh
+npm install
+npm run-script rebuild-tests
+npm test
+```
+
+Or just:
+
+``` sh
+npm install
+make test
+```
+
+<a name="governance"></a>
+## Governance & Contributing
+
+NAN is governed by the [io.js](https://iojs.org/) Addon API Working Group
+
+### Addon API Working Group (WG)
+
+The NAN project is jointly governed by a Working Group which is responsible for high-level guidance of the project.
+
+Members of the WG are also known as Collaborators, there is no distinction between the two, unlike other io.js projects.
+
+The WG has final authority over this project including:
+
+* Technical direction
+* Project governance and process (including this policy)
+* Contribution policy
+* GitHub repository hosting
+* Maintaining the list of additional Collaborators
+
+For the current list of WG members, see the project [README.md](./README.md#collaborators).
+
+Individuals making significant and valuable contributions are made members of the WG and given commit-access to the project. These individuals are identified by the WG and their addition to the WG is discussed via GitHub and requires unanimous consensus amongst those WG members participating in the discussion with a quorum of 50% of WG members required for acceptance of the vote.
+
+_Note:_ If you make a significant contribution and are not considered for commit-access log an issue or contact a WG member directly.
+
+For the current list of WG members / Collaborators, see the project [README.md](./README.md#collaborators).
+
+### Consensus Seeking Process
+
+The WG follows a [Consensus Seeking](http://en.wikipedia.org/wiki/Consensus-seeking_decision-making) decision making model.
+
+Modifications of the contents of the NAN repository are made on a collaborative basis. Anybody with a GitHub account may propose a modification via pull request and it will be considered by the WG. All pull requests must be reviewed and accepted by a WG member with sufficient expertise who is able to take full responsibility for the change. In the case of pull requests proposed by an existing WG member, an additional WG member is required for sign-off. Consensus should be sought if additional WG members participate and there is disagreement around a particular modification.
+
+If a change proposal cannot reach a consensus, a WG member can call for a vote amongst the members of the WG. Simple majority wins.
+
+### Developer's Certificate of Origin 1.0
+
+By making a contribution to this project, I certify that:
+
+* (a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or
+* (b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or
+* (c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
+
+<a name="collaborators"></a>
+### WG Members / Collaborators
+
+<table><tbody>
+<tr><th align="left">Rod Vagg</th><td><a href="https://github.com/rvagg">GitHub/rvagg</a></td><td><a href="http://twitter.com/rvagg">Twitter/@rvagg</a></td></tr>
+<tr><th align="left">Benjamin Byholm</th><td><a href="https://github.com/kkoopa/">GitHub/kkoopa</a></td><td>-</td></tr>
+<tr><th align="left">Trevor Norris</th><td><a href="https://github.com/trevnorris">GitHub/trevnorris</a></td><td><a href="http://twitter.com/trevnorris">Twitter/@trevnorris</a></td></tr>
+<tr><th align="left">Nathan Rajlich</th><td><a href="https://github.com/TooTallNate">GitHub/TooTallNate</a></td><td><a href="http://twitter.com/TooTallNate">Twitter/@TooTallNate</a></td></tr>
+<tr><th align="left">Brett Lawson</th><td><a href="https://github.com/brett19">GitHub/brett19</a></td><td><a href="http://twitter.com/brett19x">Twitter/@brett19x</a></td></tr>
+<tr><th align="left">Ben Noordhuis</th><td><a href="https://github.com/bnoordhuis">GitHub/bnoordhuis</a></td><td><a href="http://twitter.com/bnoordhuis">Twitter/@bnoordhuis</a></td></tr>
+<tr><th align="left">David Siegel</th><td><a href="https://github.com/agnat">GitHub/agnat</a></td><td>-</td></tr>
+</tbody></table>
+
+## Licence &amp; copyright
+
+Copyright (c) 2015 NAN WG Members / Collaborators (listed above).
+
+Native Abstractions for Node.js is licensed under an MIT license. All rights not explicitly granted in the MIT license are reserved. See the included LICENSE file for more details.

--- a/deps/nan/appveyor.yml
+++ b/deps/nan/appveyor.yml
@@ -1,0 +1,37 @@
+# http://www.appveyor.com/docs/appveyor-yml
+
+# Test against these versions of Io.js and Node.js.
+environment:
+  matrix:
+  # node.js
+    - nodejs_version: "0.8"
+    - nodejs_version: "0.10"
+    - nodejs_version: "0.12"
+    - nodejs_version: "3"
+    - nodejs_version: "4"
+
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of Node 0.STABLE.latest
+  - ps: Install-Product node $env:nodejs_version
+  - IF %nodejs_version% EQU 0.8 npm -g install npm@2
+  - IF %nodejs_version% EQU 0.8 set PATH=%APPDATA%\npm;%PATH%
+  - npm -g install npm
+  - IF %nodejs_version% NEQ 0.8 set PATH=%APPDATA%\npm;%PATH%
+  # Typical npm stuff.
+  - npm install
+  - npm run rebuild-tests
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  # run tests
+  - IF %nodejs_version% LSS 1 (npm test) ELSE (IF %nodejs_version% LSS 4 (iojs node_modules\tap\bin\tap.js --gc test/js/*-test.js) ELSE (node node_modules\tap\bin\tap.js --gc test/js/*-test.js))
+
+# Don't actually build.
+build: off
+
+# Set build version format here instead of in the admin panel.
+version: "{build}"

--- a/deps/nan/cpplint.py
+++ b/deps/nan/cpplint.py
@@ -1,0 +1,6323 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2009 Google Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#    * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#    * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Does google-lint on c++ files.
+
+The goal of this script is to identify places in the code that *may*
+be in non-compliance with google style.  It does not attempt to fix
+up these problems -- the point is to educate.  It does also not
+attempt to find all problems, or to ensure that everything it does
+find is legitimately a problem.
+
+In particular, we can get very confused by /* and // inside strings!
+We do a small hack, which is to ignore //'s with "'s after them on the
+same line, but it is far from perfect (in either direction).
+"""
+
+import codecs
+import copy
+import getopt
+import math  # for log
+import os
+import re
+import sre_compile
+import string
+import sys
+import unicodedata
+
+
+_USAGE = """
+Syntax: cpplint.py [--verbose=#] [--output=vs7] [--filter=-x,+y,...]
+                   [--counting=total|toplevel|detailed] [--root=subdir]
+                   [--linelength=digits]
+        <file> [file] ...
+
+  The style guidelines this tries to follow are those in
+    http://google-styleguide.googlecode.com/svn/trunk/cppguide.xml
+
+  Every problem is given a confidence score from 1-5, with 5 meaning we are
+  certain of the problem, and 1 meaning it could be a legitimate construct.
+  This will miss some errors, and is not a substitute for a code review.
+
+  To suppress false-positive errors of a certain category, add a
+  'NOLINT(category)' comment to the line.  NOLINT or NOLINT(*)
+  suppresses errors of all categories on that line.
+
+  The files passed in will be linted; at least one file must be provided.
+  Default linted extensions are .cc, .cpp, .cu, .cuh and .h.  Change the
+  extensions with the --extensions flag.
+
+  Flags:
+
+    output=vs7
+      By default, the output is formatted to ease emacs parsing.  Visual Studio
+      compatible output (vs7) may also be used.  Other formats are unsupported.
+
+    verbose=#
+      Specify a number 0-5 to restrict errors to certain verbosity levels.
+
+    filter=-x,+y,...
+      Specify a comma-separated list of category-filters to apply: only
+      error messages whose category names pass the filters will be printed.
+      (Category names are printed with the message and look like
+      "[whitespace/indent]".)  Filters are evaluated left to right.
+      "-FOO" and "FOO" means "do not print categories that start with FOO".
+      "+FOO" means "do print categories that start with FOO".
+
+      Examples: --filter=-whitespace,+whitespace/braces
+                --filter=whitespace,runtime/printf,+runtime/printf_format
+                --filter=-,+build/include_what_you_use
+
+      To see a list of all the categories used in cpplint, pass no arg:
+         --filter=
+
+    counting=total|toplevel|detailed
+      The total number of errors found is always printed. If
+      'toplevel' is provided, then the count of errors in each of
+      the top-level categories like 'build' and 'whitespace' will
+      also be printed. If 'detailed' is provided, then a count
+      is provided for each category like 'build/class'.
+
+    root=subdir
+      The root directory used for deriving header guard CPP variable.
+      By default, the header guard CPP variable is calculated as the relative
+      path to the directory that contains .git, .hg, or .svn.  When this flag
+      is specified, the relative path is calculated from the specified
+      directory. If the specified directory does not exist, this flag is
+      ignored.
+
+      Examples:
+        Assuming that src/.git exists, the header guard CPP variables for
+        src/chrome/browser/ui/browser.h are:
+
+        No flag => CHROME_BROWSER_UI_BROWSER_H_
+        --root=chrome => BROWSER_UI_BROWSER_H_
+        --root=chrome/browser => UI_BROWSER_H_
+
+    linelength=digits
+      This is the allowed line length for the project. The default value is
+      80 characters.
+
+      Examples:
+        --linelength=120
+
+    extensions=extension,extension,...
+      The allowed file extensions that cpplint will check
+
+      Examples:
+        --extensions=hpp,cpp
+
+    cpplint.py supports per-directory configurations specified in CPPLINT.cfg
+    files. CPPLINT.cfg file can contain a number of key=value pairs.
+    Currently the following options are supported:
+
+      set noparent
+      filter=+filter1,-filter2,...
+      exclude_files=regex
+      linelength=80
+
+    "set noparent" option prevents cpplint from traversing directory tree
+    upwards looking for more .cfg files in parent directories. This option
+    is usually placed in the top-level project directory.
+
+    The "filter" option is similar in function to --filter flag. It specifies
+    message filters in addition to the |_DEFAULT_FILTERS| and those specified
+    through --filter command-line flag.
+
+    "exclude_files" allows to specify a regular expression to be matched against
+    a file name. If the expression matches, the file is skipped and not run
+    through liner.
+
+    "linelength" allows to specify the allowed line length for the project.
+
+    CPPLINT.cfg has an effect on files in the same directory and all
+    sub-directories, unless overridden by a nested configuration file.
+
+      Example file:
+        filter=-build/include_order,+build/include_alpha
+        exclude_files=.*\.cc
+
+    The above example disables build/include_order warning and enables
+    build/include_alpha as well as excludes all .cc from being
+    processed by linter, in the current directory (where the .cfg
+    file is located) and all sub-directories.
+"""
+
+# We categorize each error message we print.  Here are the categories.
+# We want an explicit list so we can list them all in cpplint --filter=.
+# If you add a new error message with a new category, add it to the list
+# here!  cpplint_unittest.py should tell you if you forget to do this.
+_ERROR_CATEGORIES = [
+    'build/class',
+    'build/c++11',
+    'build/deprecated',
+    'build/endif_comment',
+    'build/explicit_make_pair',
+    'build/forward_decl',
+    'build/header_guard',
+    'build/include',
+    'build/include_alpha',
+    'build/include_order',
+    'build/include_what_you_use',
+    'build/namespaces',
+    'build/printf_format',
+    'build/storage_class',
+    'legal/copyright',
+    'readability/alt_tokens',
+    'readability/braces',
+    'readability/casting',
+    'readability/check',
+    'readability/constructors',
+    'readability/fn_size',
+    'readability/function',
+    'readability/inheritance',
+    'readability/multiline_comment',
+    'readability/multiline_string',
+    'readability/namespace',
+    'readability/nolint',
+    'readability/nul',
+    'readability/strings',
+    'readability/todo',
+    'readability/utf8',
+    'runtime/arrays',
+    'runtime/casting',
+    'runtime/explicit',
+    'runtime/int',
+    'runtime/init',
+    'runtime/invalid_increment',
+    'runtime/member_string_references',
+    'runtime/memset',
+    'runtime/indentation_namespace',
+    'runtime/operator',
+    'runtime/printf',
+    'runtime/printf_format',
+    'runtime/references',
+    'runtime/string',
+    'runtime/threadsafe_fn',
+    'runtime/vlog',
+    'whitespace/blank_line',
+    'whitespace/braces',
+    'whitespace/comma',
+    'whitespace/comments',
+    'whitespace/empty_conditional_body',
+    'whitespace/empty_loop_body',
+    'whitespace/end_of_line',
+    'whitespace/ending_newline',
+    'whitespace/forcolon',
+    'whitespace/indent',
+    'whitespace/line_length',
+    'whitespace/newline',
+    'whitespace/operators',
+    'whitespace/parens',
+    'whitespace/semicolon',
+    'whitespace/tab',
+    'whitespace/todo',
+    ]
+
+# These error categories are no longer enforced by cpplint, but for backwards-
+# compatibility they may still appear in NOLINT comments.
+_LEGACY_ERROR_CATEGORIES = [
+    'readability/streams',
+    ]
+
+# The default state of the category filter. This is overridden by the --filter=
+# flag. By default all errors are on, so only add here categories that should be
+# off by default (i.e., categories that must be enabled by the --filter= flags).
+# All entries here should start with a '-' or '+', as in the --filter= flag.
+_DEFAULT_FILTERS = ['-build/include_alpha']
+
+# We used to check for high-bit characters, but after much discussion we
+# decided those were OK, as long as they were in UTF-8 and didn't represent
+# hard-coded international strings, which belong in a separate i18n file.
+
+# C++ headers
+_CPP_HEADERS = frozenset([
+    # Legacy
+    'algobase.h',
+    'algo.h',
+    'alloc.h',
+    'builtinbuf.h',
+    'bvector.h',
+    'complex.h',
+    'defalloc.h',
+    'deque.h',
+    'editbuf.h',
+    'fstream.h',
+    'function.h',
+    'hash_map',
+    'hash_map.h',
+    'hash_set',
+    'hash_set.h',
+    'hashtable.h',
+    'heap.h',
+    'indstream.h',
+    'iomanip.h',
+    'iostream.h',
+    'istream.h',
+    'iterator.h',
+    'list.h',
+    'map.h',
+    'multimap.h',
+    'multiset.h',
+    'ostream.h',
+    'pair.h',
+    'parsestream.h',
+    'pfstream.h',
+    'procbuf.h',
+    'pthread_alloc',
+    'pthread_alloc.h',
+    'rope',
+    'rope.h',
+    'ropeimpl.h',
+    'set.h',
+    'slist',
+    'slist.h',
+    'stack.h',
+    'stdiostream.h',
+    'stl_alloc.h',
+    'stl_relops.h',
+    'streambuf.h',
+    'stream.h',
+    'strfile.h',
+    'strstream.h',
+    'tempbuf.h',
+    'tree.h',
+    'type_traits.h',
+    'vector.h',
+    # 17.6.1.2 C++ library headers
+    'algorithm',
+    'array',
+    'atomic',
+    'bitset',
+    'chrono',
+    'codecvt',
+    'complex',
+    'condition_variable',
+    'deque',
+    'exception',
+    'forward_list',
+    'fstream',
+    'functional',
+    'future',
+    'initializer_list',
+    'iomanip',
+    'ios',
+    'iosfwd',
+    'iostream',
+    'istream',
+    'iterator',
+    'limits',
+    'list',
+    'locale',
+    'map',
+    'memory',
+    'mutex',
+    'new',
+    'numeric',
+    'ostream',
+    'queue',
+    'random',
+    'ratio',
+    'regex',
+    'set',
+    'sstream',
+    'stack',
+    'stdexcept',
+    'streambuf',
+    'string',
+    'strstream',
+    'system_error',
+    'thread',
+    'tuple',
+    'typeindex',
+    'typeinfo',
+    'type_traits',
+    'unordered_map',
+    'unordered_set',
+    'utility',
+    'valarray',
+    'vector',
+    # 17.6.1.2 C++ headers for C library facilities
+    'cassert',
+    'ccomplex',
+    'cctype',
+    'cerrno',
+    'cfenv',
+    'cfloat',
+    'cinttypes',
+    'ciso646',
+    'climits',
+    'clocale',
+    'cmath',
+    'csetjmp',
+    'csignal',
+    'cstdalign',
+    'cstdarg',
+    'cstdbool',
+    'cstddef',
+    'cstdint',
+    'cstdio',
+    'cstdlib',
+    'cstring',
+    'ctgmath',
+    'ctime',
+    'cuchar',
+    'cwchar',
+    'cwctype',
+    ])
+
+
+# These headers are excluded from [build/include] and [build/include_order]
+# checks:
+# - Anything not following google file name conventions (containing an
+#   uppercase character, such as Python.h or nsStringAPI.h, for example).
+# - Lua headers.
+_THIRD_PARTY_HEADERS_PATTERN = re.compile(
+    r'^(?:[^/]*[A-Z][^/]*\.h|lua\.h|lauxlib\.h|lualib\.h)$')
+
+
+# Assertion macros.  These are defined in base/logging.h and
+# testing/base/gunit.h.  Note that the _M versions need to come first
+# for substring matching to work.
+_CHECK_MACROS = [
+    'DCHECK', 'CHECK',
+    'EXPECT_TRUE_M', 'EXPECT_TRUE',
+    'ASSERT_TRUE_M', 'ASSERT_TRUE',
+    'EXPECT_FALSE_M', 'EXPECT_FALSE',
+    'ASSERT_FALSE_M', 'ASSERT_FALSE',
+    ]
+
+# Replacement macros for CHECK/DCHECK/EXPECT_TRUE/EXPECT_FALSE
+_CHECK_REPLACEMENT = dict([(m, {}) for m in _CHECK_MACROS])
+
+for op, replacement in [('==', 'EQ'), ('!=', 'NE'),
+                        ('>=', 'GE'), ('>', 'GT'),
+                        ('<=', 'LE'), ('<', 'LT')]:
+  _CHECK_REPLACEMENT['DCHECK'][op] = 'DCHECK_%s' % replacement
+  _CHECK_REPLACEMENT['CHECK'][op] = 'CHECK_%s' % replacement
+  _CHECK_REPLACEMENT['EXPECT_TRUE'][op] = 'EXPECT_%s' % replacement
+  _CHECK_REPLACEMENT['ASSERT_TRUE'][op] = 'ASSERT_%s' % replacement
+  _CHECK_REPLACEMENT['EXPECT_TRUE_M'][op] = 'EXPECT_%s_M' % replacement
+  _CHECK_REPLACEMENT['ASSERT_TRUE_M'][op] = 'ASSERT_%s_M' % replacement
+
+for op, inv_replacement in [('==', 'NE'), ('!=', 'EQ'),
+                            ('>=', 'LT'), ('>', 'LE'),
+                            ('<=', 'GT'), ('<', 'GE')]:
+  _CHECK_REPLACEMENT['EXPECT_FALSE'][op] = 'EXPECT_%s' % inv_replacement
+  _CHECK_REPLACEMENT['ASSERT_FALSE'][op] = 'ASSERT_%s' % inv_replacement
+  _CHECK_REPLACEMENT['EXPECT_FALSE_M'][op] = 'EXPECT_%s_M' % inv_replacement
+  _CHECK_REPLACEMENT['ASSERT_FALSE_M'][op] = 'ASSERT_%s_M' % inv_replacement
+
+# Alternative tokens and their replacements.  For full list, see section 2.5
+# Alternative tokens [lex.digraph] in the C++ standard.
+#
+# Digraphs (such as '%:') are not included here since it's a mess to
+# match those on a word boundary.
+_ALT_TOKEN_REPLACEMENT = {
+    'and': '&&',
+    'bitor': '|',
+    'or': '||',
+    'xor': '^',
+    'compl': '~',
+    'bitand': '&',
+    'and_eq': '&=',
+    'or_eq': '|=',
+    'xor_eq': '^=',
+    'not': '!',
+    'not_eq': '!='
+    }
+
+# Compile regular expression that matches all the above keywords.  The "[ =()]"
+# bit is meant to avoid matching these keywords outside of boolean expressions.
+#
+# False positives include C-style multi-line comments and multi-line strings
+# but those have always been troublesome for cpplint.
+_ALT_TOKEN_REPLACEMENT_PATTERN = re.compile(
+    r'[ =()](' + ('|'.join(_ALT_TOKEN_REPLACEMENT.keys())) + r')(?=[ (]|$)')
+
+
+# These constants define types of headers for use with
+# _IncludeState.CheckNextIncludeOrder().
+_C_SYS_HEADER = 1
+_CPP_SYS_HEADER = 2
+_LIKELY_MY_HEADER = 3
+_POSSIBLE_MY_HEADER = 4
+_OTHER_HEADER = 5
+
+# These constants define the current inline assembly state
+_NO_ASM = 0       # Outside of inline assembly block
+_INSIDE_ASM = 1   # Inside inline assembly block
+_END_ASM = 2      # Last line of inline assembly block
+_BLOCK_ASM = 3    # The whole block is an inline assembly block
+
+# Match start of assembly blocks
+_MATCH_ASM = re.compile(r'^\s*(?:asm|_asm|__asm|__asm__)'
+                        r'(?:\s+(volatile|__volatile__))?'
+                        r'\s*[{(]')
+
+
+_regexp_compile_cache = {}
+
+# {str, set(int)}: a map from error categories to sets of linenumbers
+# on which those errors are expected and should be suppressed.
+_error_suppressions = {}
+
+# The root directory used for deriving header guard CPP variable.
+# This is set by --root flag.
+_root = None
+
+# The allowed line length of files.
+# This is set by --linelength flag.
+_line_length = 80
+
+# The allowed extensions for file names
+# This is set by --extensions flag.
+_valid_extensions = set(['cc', 'h', 'cpp', 'cu', 'cuh'])
+
+def ParseNolintSuppressions(filename, raw_line, linenum, error):
+  """Updates the global list of error-suppressions.
+
+  Parses any NOLINT comments on the current line, updating the global
+  error_suppressions store.  Reports an error if the NOLINT comment
+  was malformed.
+
+  Args:
+    filename: str, the name of the input file.
+    raw_line: str, the line of input text, with comments.
+    linenum: int, the number of the current line.
+    error: function, an error handler.
+  """
+  matched = Search(r'\bNOLINT(NEXTLINE)?\b(\([^)]+\))?', raw_line)
+  if matched:
+    if matched.group(1):
+      suppressed_line = linenum + 1
+    else:
+      suppressed_line = linenum
+    category = matched.group(2)
+    if category in (None, '(*)'):  # => "suppress all"
+      _error_suppressions.setdefault(None, set()).add(suppressed_line)
+    else:
+      if category.startswith('(') and category.endswith(')'):
+        category = category[1:-1]
+        if category in _ERROR_CATEGORIES:
+          _error_suppressions.setdefault(category, set()).add(suppressed_line)
+        elif category not in _LEGACY_ERROR_CATEGORIES:
+          error(filename, linenum, 'readability/nolint', 5,
+                'Unknown NOLINT error category: %s' % category)
+
+
+def ResetNolintSuppressions():
+  """Resets the set of NOLINT suppressions to empty."""
+  _error_suppressions.clear()
+
+
+def IsErrorSuppressedByNolint(category, linenum):
+  """Returns true if the specified error category is suppressed on this line.
+
+  Consults the global error_suppressions map populated by
+  ParseNolintSuppressions/ResetNolintSuppressions.
+
+  Args:
+    category: str, the category of the error.
+    linenum: int, the current line number.
+  Returns:
+    bool, True iff the error should be suppressed due to a NOLINT comment.
+  """
+  return (linenum in _error_suppressions.get(category, set()) or
+          linenum in _error_suppressions.get(None, set()))
+
+
+def Match(pattern, s):
+  """Matches the string with the pattern, caching the compiled regexp."""
+  # The regexp compilation caching is inlined in both Match and Search for
+  # performance reasons; factoring it out into a separate function turns out
+  # to be noticeably expensive.
+  if pattern not in _regexp_compile_cache:
+    _regexp_compile_cache[pattern] = sre_compile.compile(pattern)
+  return _regexp_compile_cache[pattern].match(s)
+
+
+def ReplaceAll(pattern, rep, s):
+  """Replaces instances of pattern in a string with a replacement.
+
+  The compiled regex is kept in a cache shared by Match and Search.
+
+  Args:
+    pattern: regex pattern
+    rep: replacement text
+    s: search string
+
+  Returns:
+    string with replacements made (or original string if no replacements)
+  """
+  if pattern not in _regexp_compile_cache:
+    _regexp_compile_cache[pattern] = sre_compile.compile(pattern)
+  return _regexp_compile_cache[pattern].sub(rep, s)
+
+
+def Search(pattern, s):
+  """Searches the string for the pattern, caching the compiled regexp."""
+  if pattern not in _regexp_compile_cache:
+    _regexp_compile_cache[pattern] = sre_compile.compile(pattern)
+  return _regexp_compile_cache[pattern].search(s)
+
+
+class _IncludeState(object):
+  """Tracks line numbers for includes, and the order in which includes appear.
+
+  include_list contains list of lists of (header, line number) pairs.
+  It's a lists of lists rather than just one flat list to make it
+  easier to update across preprocessor boundaries.
+
+  Call CheckNextIncludeOrder() once for each header in the file, passing
+  in the type constants defined above. Calls in an illegal order will
+  raise an _IncludeError with an appropriate error message.
+
+  """
+  # self._section will move monotonically through this set. If it ever
+  # needs to move backwards, CheckNextIncludeOrder will raise an error.
+  _INITIAL_SECTION = 0
+  _MY_H_SECTION = 1
+  _C_SECTION = 2
+  _CPP_SECTION = 3
+  _OTHER_H_SECTION = 4
+
+  _TYPE_NAMES = {
+      _C_SYS_HEADER: 'C system header',
+      _CPP_SYS_HEADER: 'C++ system header',
+      _LIKELY_MY_HEADER: 'header this file implements',
+      _POSSIBLE_MY_HEADER: 'header this file may implement',
+      _OTHER_HEADER: 'other header',
+      }
+  _SECTION_NAMES = {
+      _INITIAL_SECTION: "... nothing. (This can't be an error.)",
+      _MY_H_SECTION: 'a header this file implements',
+      _C_SECTION: 'C system header',
+      _CPP_SECTION: 'C++ system header',
+      _OTHER_H_SECTION: 'other header',
+      }
+
+  def __init__(self):
+    self.include_list = [[]]
+    self.ResetSection('')
+
+  def FindHeader(self, header):
+    """Check if a header has already been included.
+
+    Args:
+      header: header to check.
+    Returns:
+      Line number of previous occurrence, or -1 if the header has not
+      been seen before.
+    """
+    for section_list in self.include_list:
+      for f in section_list:
+        if f[0] == header:
+          return f[1]
+    return -1
+
+  def ResetSection(self, directive):
+    """Reset section checking for preprocessor directive.
+
+    Args:
+      directive: preprocessor directive (e.g. "if", "else").
+    """
+    # The name of the current section.
+    self._section = self._INITIAL_SECTION
+    # The path of last found header.
+    self._last_header = ''
+
+    # Update list of includes.  Note that we never pop from the
+    # include list.
+    if directive in ('if', 'ifdef', 'ifndef'):
+      self.include_list.append([])
+    elif directive in ('else', 'elif'):
+      self.include_list[-1] = []
+
+  def SetLastHeader(self, header_path):
+    self._last_header = header_path
+
+  def CanonicalizeAlphabeticalOrder(self, header_path):
+    """Returns a path canonicalized for alphabetical comparison.
+
+    - replaces "-" with "_" so they both cmp the same.
+    - removes '-inl' since we don't require them to be after the main header.
+    - lowercase everything, just in case.
+
+    Args:
+      header_path: Path to be canonicalized.
+
+    Returns:
+      Canonicalized path.
+    """
+    return header_path.replace('-inl.h', '.h').replace('-', '_').lower()
+
+  def IsInAlphabeticalOrder(self, clean_lines, linenum, header_path):
+    """Check if a header is in alphabetical order with the previous header.
+
+    Args:
+      clean_lines: A CleansedLines instance containing the file.
+      linenum: The number of the line to check.
+      header_path: Canonicalized header to be checked.
+
+    Returns:
+      Returns true if the header is in alphabetical order.
+    """
+    # If previous section is different from current section, _last_header will
+    # be reset to empty string, so it's always less than current header.
+    #
+    # If previous line was a blank line, assume that the headers are
+    # intentionally sorted the way they are.
+    if (self._last_header > header_path and
+        Match(r'^\s*#\s*include\b', clean_lines.elided[linenum - 1])):
+      return False
+    return True
+
+  def CheckNextIncludeOrder(self, header_type):
+    """Returns a non-empty error message if the next header is out of order.
+
+    This function also updates the internal state to be ready to check
+    the next include.
+
+    Args:
+      header_type: One of the _XXX_HEADER constants defined above.
+
+    Returns:
+      The empty string if the header is in the right order, or an
+      error message describing what's wrong.
+
+    """
+    error_message = ('Found %s after %s' %
+                     (self._TYPE_NAMES[header_type],
+                      self._SECTION_NAMES[self._section]))
+
+    last_section = self._section
+
+    if header_type == _C_SYS_HEADER:
+      if self._section <= self._C_SECTION:
+        self._section = self._C_SECTION
+      else:
+        self._last_header = ''
+        return error_message
+    elif header_type == _CPP_SYS_HEADER:
+      if self._section <= self._CPP_SECTION:
+        self._section = self._CPP_SECTION
+      else:
+        self._last_header = ''
+        return error_message
+    elif header_type == _LIKELY_MY_HEADER:
+      if self._section <= self._MY_H_SECTION:
+        self._section = self._MY_H_SECTION
+      else:
+        self._section = self._OTHER_H_SECTION
+    elif header_type == _POSSIBLE_MY_HEADER:
+      if self._section <= self._MY_H_SECTION:
+        self._section = self._MY_H_SECTION
+      else:
+        # This will always be the fallback because we're not sure
+        # enough that the header is associated with this file.
+        self._section = self._OTHER_H_SECTION
+    else:
+      assert header_type == _OTHER_HEADER
+      self._section = self._OTHER_H_SECTION
+
+    if last_section != self._section:
+      self._last_header = ''
+
+    return ''
+
+
+class _CppLintState(object):
+  """Maintains module-wide state.."""
+
+  def __init__(self):
+    self.verbose_level = 1  # global setting.
+    self.error_count = 0    # global count of reported errors
+    # filters to apply when emitting error messages
+    self.filters = _DEFAULT_FILTERS[:]
+    # backup of filter list. Used to restore the state after each file.
+    self._filters_backup = self.filters[:]
+    self.counting = 'total'  # In what way are we counting errors?
+    self.errors_by_category = {}  # string to int dict storing error counts
+
+    # output format:
+    # "emacs" - format that emacs can parse (default)
+    # "vs7" - format that Microsoft Visual Studio 7 can parse
+    self.output_format = 'emacs'
+
+  def SetOutputFormat(self, output_format):
+    """Sets the output format for errors."""
+    self.output_format = output_format
+
+  def SetVerboseLevel(self, level):
+    """Sets the module's verbosity, and returns the previous setting."""
+    last_verbose_level = self.verbose_level
+    self.verbose_level = level
+    return last_verbose_level
+
+  def SetCountingStyle(self, counting_style):
+    """Sets the module's counting options."""
+    self.counting = counting_style
+
+  def SetFilters(self, filters):
+    """Sets the error-message filters.
+
+    These filters are applied when deciding whether to emit a given
+    error message.
+
+    Args:
+      filters: A string of comma-separated filters (eg "+whitespace/indent").
+               Each filter should start with + or -; else we die.
+
+    Raises:
+      ValueError: The comma-separated filters did not all start with '+' or '-'.
+                  E.g. "-,+whitespace,-whitespace/indent,whitespace/badfilter"
+    """
+    # Default filters always have less priority than the flag ones.
+    self.filters = _DEFAULT_FILTERS[:]
+    self.AddFilters(filters)
+
+  def AddFilters(self, filters):
+    """ Adds more filters to the existing list of error-message filters. """
+    for filt in filters.split(','):
+      clean_filt = filt.strip()
+      if clean_filt:
+        self.filters.append(clean_filt)
+    for filt in self.filters:
+      if not (filt.startswith('+') or filt.startswith('-')):
+        raise ValueError('Every filter in --filters must start with + or -'
+                         ' (%s does not)' % filt)
+
+  def BackupFilters(self):
+    """ Saves the current filter list to backup storage."""
+    self._filters_backup = self.filters[:]
+
+  def RestoreFilters(self):
+    """ Restores filters previously backed up."""
+    self.filters = self._filters_backup[:]
+
+  def ResetErrorCounts(self):
+    """Sets the module's error statistic back to zero."""
+    self.error_count = 0
+    self.errors_by_category = {}
+
+  def IncrementErrorCount(self, category):
+    """Bumps the module's error statistic."""
+    self.error_count += 1
+    if self.counting in ('toplevel', 'detailed'):
+      if self.counting != 'detailed':
+        category = category.split('/')[0]
+      if category not in self.errors_by_category:
+        self.errors_by_category[category] = 0
+      self.errors_by_category[category] += 1
+
+  def PrintErrorCounts(self):
+    """Print a summary of errors by category, and the total."""
+    for category, count in self.errors_by_category.iteritems():
+      sys.stderr.write('Category \'%s\' errors found: %d\n' %
+                       (category, count))
+    sys.stderr.write('Total errors found: %d\n' % self.error_count)
+
+_cpplint_state = _CppLintState()
+
+
+def _OutputFormat():
+  """Gets the module's output format."""
+  return _cpplint_state.output_format
+
+
+def _SetOutputFormat(output_format):
+  """Sets the module's output format."""
+  _cpplint_state.SetOutputFormat(output_format)
+
+
+def _VerboseLevel():
+  """Returns the module's verbosity setting."""
+  return _cpplint_state.verbose_level
+
+
+def _SetVerboseLevel(level):
+  """Sets the module's verbosity, and returns the previous setting."""
+  return _cpplint_state.SetVerboseLevel(level)
+
+
+def _SetCountingStyle(level):
+  """Sets the module's counting options."""
+  _cpplint_state.SetCountingStyle(level)
+
+
+def _Filters():
+  """Returns the module's list of output filters, as a list."""
+  return _cpplint_state.filters
+
+
+def _SetFilters(filters):
+  """Sets the module's error-message filters.
+
+  These filters are applied when deciding whether to emit a given
+  error message.
+
+  Args:
+    filters: A string of comma-separated filters (eg "whitespace/indent").
+             Each filter should start with + or -; else we die.
+  """
+  _cpplint_state.SetFilters(filters)
+
+def _AddFilters(filters):
+  """Adds more filter overrides.
+
+  Unlike _SetFilters, this function does not reset the current list of filters
+  available.
+
+  Args:
+    filters: A string of comma-separated filters (eg "whitespace/indent").
+             Each filter should start with + or -; else we die.
+  """
+  _cpplint_state.AddFilters(filters)
+
+def _BackupFilters():
+  """ Saves the current filter list to backup storage."""
+  _cpplint_state.BackupFilters()
+
+def _RestoreFilters():
+  """ Restores filters previously backed up."""
+  _cpplint_state.RestoreFilters()
+
+class _FunctionState(object):
+  """Tracks current function name and the number of lines in its body."""
+
+  _NORMAL_TRIGGER = 250  # for --v=0, 500 for --v=1, etc.
+  _TEST_TRIGGER = 400    # about 50% more than _NORMAL_TRIGGER.
+
+  def __init__(self):
+    self.in_a_function = False
+    self.lines_in_function = 0
+    self.current_function = ''
+
+  def Begin(self, function_name):
+    """Start analyzing function body.
+
+    Args:
+      function_name: The name of the function being tracked.
+    """
+    self.in_a_function = True
+    self.lines_in_function = 0
+    self.current_function = function_name
+
+  def Count(self):
+    """Count line in current function body."""
+    if self.in_a_function:
+      self.lines_in_function += 1
+
+  def Check(self, error, filename, linenum):
+    """Report if too many lines in function body.
+
+    Args:
+      error: The function to call with any errors found.
+      filename: The name of the current file.
+      linenum: The number of the line to check.
+    """
+    if Match(r'T(EST|est)', self.current_function):
+      base_trigger = self._TEST_TRIGGER
+    else:
+      base_trigger = self._NORMAL_TRIGGER
+    trigger = base_trigger * 2**_VerboseLevel()
+
+    if self.lines_in_function > trigger:
+      error_level = int(math.log(self.lines_in_function / base_trigger, 2))
+      # 50 => 0, 100 => 1, 200 => 2, 400 => 3, 800 => 4, 1600 => 5, ...
+      if error_level > 5:
+        error_level = 5
+      error(filename, linenum, 'readability/fn_size', error_level,
+            'Small and focused functions are preferred:'
+            ' %s has %d non-comment lines'
+            ' (error triggered by exceeding %d lines).'  % (
+                self.current_function, self.lines_in_function, trigger))
+
+  def End(self):
+    """Stop analyzing function body."""
+    self.in_a_function = False
+
+
+class _IncludeError(Exception):
+  """Indicates a problem with the include order in a file."""
+  pass
+
+
+class FileInfo(object):
+  """Provides utility functions for filenames.
+
+  FileInfo provides easy access to the components of a file's path
+  relative to the project root.
+  """
+
+  def __init__(self, filename):
+    self._filename = filename
+
+  def FullName(self):
+    """Make Windows paths like Unix."""
+    return os.path.abspath(self._filename).replace('\\', '/')
+
+  def RepositoryName(self):
+    """FullName after removing the local path to the repository.
+
+    If we have a real absolute path name here we can try to do something smart:
+    detecting the root of the checkout and truncating /path/to/checkout from
+    the name so that we get header guards that don't include things like
+    "C:\Documents and Settings\..." or "/home/username/..." in them and thus
+    people on different computers who have checked the source out to different
+    locations won't see bogus errors.
+    """
+    fullname = self.FullName()
+
+    if os.path.exists(fullname):
+      project_dir = os.path.dirname(fullname)
+
+      if os.path.exists(os.path.join(project_dir, ".svn")):
+        # If there's a .svn file in the current directory, we recursively look
+        # up the directory tree for the top of the SVN checkout
+        root_dir = project_dir
+        one_up_dir = os.path.dirname(root_dir)
+        while os.path.exists(os.path.join(one_up_dir, ".svn")):
+          root_dir = os.path.dirname(root_dir)
+          one_up_dir = os.path.dirname(one_up_dir)
+
+        prefix = os.path.commonprefix([root_dir, project_dir])
+        return fullname[len(prefix) + 1:]
+
+      # Not SVN <= 1.6? Try to find a git, hg, or svn top level directory by
+      # searching up from the current path.
+      root_dir = os.path.dirname(fullname)
+      while (root_dir != os.path.dirname(root_dir) and
+             not os.path.exists(os.path.join(root_dir, ".git")) and
+             not os.path.exists(os.path.join(root_dir, ".hg")) and
+             not os.path.exists(os.path.join(root_dir, ".svn"))):
+        root_dir = os.path.dirname(root_dir)
+
+      if (os.path.exists(os.path.join(root_dir, ".git")) or
+          os.path.exists(os.path.join(root_dir, ".hg")) or
+          os.path.exists(os.path.join(root_dir, ".svn"))):
+        prefix = os.path.commonprefix([root_dir, project_dir])
+        return fullname[len(prefix) + 1:]
+
+    # Don't know what to do; header guard warnings may be wrong...
+    return fullname
+
+  def Split(self):
+    """Splits the file into the directory, basename, and extension.
+
+    For 'chrome/browser/browser.cc', Split() would
+    return ('chrome/browser', 'browser', '.cc')
+
+    Returns:
+      A tuple of (directory, basename, extension).
+    """
+
+    googlename = self.RepositoryName()
+    project, rest = os.path.split(googlename)
+    return (project,) + os.path.splitext(rest)
+
+  def BaseName(self):
+    """File base name - text after the final slash, before the final period."""
+    return self.Split()[1]
+
+  def Extension(self):
+    """File extension - text following the final period."""
+    return self.Split()[2]
+
+  def NoExtension(self):
+    """File has no source file extension."""
+    return '/'.join(self.Split()[0:2])
+
+  def IsSource(self):
+    """File has a source file extension."""
+    return self.Extension()[1:] in ('c', 'cc', 'cpp', 'cxx')
+
+
+def _ShouldPrintError(category, confidence, linenum):
+  """If confidence >= verbose, category passes filter and is not suppressed."""
+
+  # There are three ways we might decide not to print an error message:
+  # a "NOLINT(category)" comment appears in the source,
+  # the verbosity level isn't high enough, or the filters filter it out.
+  if IsErrorSuppressedByNolint(category, linenum):
+    return False
+
+  if confidence < _cpplint_state.verbose_level:
+    return False
+
+  is_filtered = False
+  for one_filter in _Filters():
+    if one_filter.startswith('-'):
+      if category.startswith(one_filter[1:]):
+        is_filtered = True
+    elif one_filter.startswith('+'):
+      if category.startswith(one_filter[1:]):
+        is_filtered = False
+    else:
+      assert False  # should have been checked for in SetFilter.
+  if is_filtered:
+    return False
+
+  return True
+
+
+def Error(filename, linenum, category, confidence, message):
+  """Logs the fact we've found a lint error.
+
+  We log where the error was found, and also our confidence in the error,
+  that is, how certain we are this is a legitimate style regression, and
+  not a misidentification or a use that's sometimes justified.
+
+  False positives can be suppressed by the use of
+  "cpplint(category)"  comments on the offending line.  These are
+  parsed into _error_suppressions.
+
+  Args:
+    filename: The name of the file containing the error.
+    linenum: The number of the line containing the error.
+    category: A string used to describe the "category" this bug
+      falls under: "whitespace", say, or "runtime".  Categories
+      may have a hierarchy separated by slashes: "whitespace/indent".
+    confidence: A number from 1-5 representing a confidence score for
+      the error, with 5 meaning that we are certain of the problem,
+      and 1 meaning that it could be a legitimate construct.
+    message: The error message.
+  """
+  if _ShouldPrintError(category, confidence, linenum):
+    _cpplint_state.IncrementErrorCount(category)
+    if _cpplint_state.output_format == 'vs7':
+      sys.stderr.write('%s(%s):  %s  [%s] [%d]\n' % (
+          filename, linenum, message, category, confidence))
+    elif _cpplint_state.output_format == 'eclipse':
+      sys.stderr.write('%s:%s: warning: %s  [%s] [%d]\n' % (
+          filename, linenum, message, category, confidence))
+    else:
+      sys.stderr.write('%s:%s:  %s  [%s] [%d]\n' % (
+          filename, linenum, message, category, confidence))
+
+
+# Matches standard C++ escape sequences per 2.13.2.3 of the C++ standard.
+_RE_PATTERN_CLEANSE_LINE_ESCAPES = re.compile(
+    r'\\([abfnrtv?"\\\']|\d+|x[0-9a-fA-F]+)')
+# Match a single C style comment on the same line.
+_RE_PATTERN_C_COMMENTS = r'/\*(?:[^*]|\*(?!/))*\*/'
+# Matches multi-line C style comments.
+# This RE is a little bit more complicated than one might expect, because we
+# have to take care of space removals tools so we can handle comments inside
+# statements better.
+# The current rule is: We only clear spaces from both sides when we're at the
+# end of the line. Otherwise, we try to remove spaces from the right side,
+# if this doesn't work we try on left side but only if there's a non-character
+# on the right.
+_RE_PATTERN_CLEANSE_LINE_C_COMMENTS = re.compile(
+    r'(\s*' + _RE_PATTERN_C_COMMENTS + r'\s*$|' +
+    _RE_PATTERN_C_COMMENTS + r'\s+|' +
+    r'\s+' + _RE_PATTERN_C_COMMENTS + r'(?=\W)|' +
+    _RE_PATTERN_C_COMMENTS + r')')
+
+
+def IsCppString(line):
+  """Does line terminate so, that the next symbol is in string constant.
+
+  This function does not consider single-line nor multi-line comments.
+
+  Args:
+    line: is a partial line of code starting from the 0..n.
+
+  Returns:
+    True, if next character appended to 'line' is inside a
+    string constant.
+  """
+
+  line = line.replace(r'\\', 'XX')  # after this, \\" does not match to \"
+  return ((line.count('"') - line.count(r'\"') - line.count("'\"'")) & 1) == 1
+
+
+def CleanseRawStrings(raw_lines):
+  """Removes C++11 raw strings from lines.
+
+    Before:
+      static const char kData[] = R"(
+          multi-line string
+          )";
+
+    After:
+      static const char kData[] = ""
+          (replaced by blank line)
+          "";
+
+  Args:
+    raw_lines: list of raw lines.
+
+  Returns:
+    list of lines with C++11 raw strings replaced by empty strings.
+  """
+
+  delimiter = None
+  lines_without_raw_strings = []
+  for line in raw_lines:
+    if delimiter:
+      # Inside a raw string, look for the end
+      end = line.find(delimiter)
+      if end >= 0:
+        # Found the end of the string, match leading space for this
+        # line and resume copying the original lines, and also insert
+        # a "" on the last line.
+        leading_space = Match(r'^(\s*)\S', line)
+        line = leading_space.group(1) + '""' + line[end + len(delimiter):]
+        delimiter = None
+      else:
+        # Haven't found the end yet, append a blank line.
+        line = '""'
+
+    # Look for beginning of a raw string, and replace them with
+    # empty strings.  This is done in a loop to handle multiple raw
+    # strings on the same line.
+    while delimiter is None:
+      # Look for beginning of a raw string.
+      # See 2.14.15 [lex.string] for syntax.
+      matched = Match(r'^(.*)\b(?:R|u8R|uR|UR|LR)"([^\s\\()]*)\((.*)$', line)
+      if matched:
+        delimiter = ')' + matched.group(2) + '"'
+
+        end = matched.group(3).find(delimiter)
+        if end >= 0:
+          # Raw string ended on same line
+          line = (matched.group(1) + '""' +
+                  matched.group(3)[end + len(delimiter):])
+          delimiter = None
+        else:
+          # Start of a multi-line raw string
+          line = matched.group(1) + '""'
+      else:
+        break
+
+    lines_without_raw_strings.append(line)
+
+  # TODO(unknown): if delimiter is not None here, we might want to
+  # emit a warning for unterminated string.
+  return lines_without_raw_strings
+
+
+def FindNextMultiLineCommentStart(lines, lineix):
+  """Find the beginning marker for a multiline comment."""
+  while lineix < len(lines):
+    if lines[lineix].strip().startswith('/*'):
+      # Only return this marker if the comment goes beyond this line
+      if lines[lineix].strip().find('*/', 2) < 0:
+        return lineix
+    lineix += 1
+  return len(lines)
+
+
+def FindNextMultiLineCommentEnd(lines, lineix):
+  """We are inside a comment, find the end marker."""
+  while lineix < len(lines):
+    if lines[lineix].strip().endswith('*/'):
+      return lineix
+    lineix += 1
+  return len(lines)
+
+
+def RemoveMultiLineCommentsFromRange(lines, begin, end):
+  """Clears a range of lines for multi-line comments."""
+  # Having // dummy comments makes the lines non-empty, so we will not get
+  # unnecessary blank line warnings later in the code.
+  for i in range(begin, end):
+    lines[i] = '/**/'
+
+
+def RemoveMultiLineComments(filename, lines, error):
+  """Removes multiline (c-style) comments from lines."""
+  lineix = 0
+  while lineix < len(lines):
+    lineix_begin = FindNextMultiLineCommentStart(lines, lineix)
+    if lineix_begin >= len(lines):
+      return
+    lineix_end = FindNextMultiLineCommentEnd(lines, lineix_begin)
+    if lineix_end >= len(lines):
+      error(filename, lineix_begin + 1, 'readability/multiline_comment', 5,
+            'Could not find end of multi-line comment')
+      return
+    RemoveMultiLineCommentsFromRange(lines, lineix_begin, lineix_end + 1)
+    lineix = lineix_end + 1
+
+
+def CleanseComments(line):
+  """Removes //-comments and single-line C-style /* */ comments.
+
+  Args:
+    line: A line of C++ source.
+
+  Returns:
+    The line with single-line comments removed.
+  """
+  commentpos = line.find('//')
+  if commentpos != -1 and not IsCppString(line[:commentpos]):
+    line = line[:commentpos].rstrip()
+  # get rid of /* ... */
+  return _RE_PATTERN_CLEANSE_LINE_C_COMMENTS.sub('', line)
+
+
+class CleansedLines(object):
+  """Holds 4 copies of all lines with different preprocessing applied to them.
+
+  1) elided member contains lines without strings and comments.
+  2) lines member contains lines without comments.
+  3) raw_lines member contains all the lines without processing.
+  4) lines_without_raw_strings member is same as raw_lines, but with C++11 raw
+     strings removed.
+  All these members are of <type 'list'>, and of the same length.
+  """
+
+  def __init__(self, lines):
+    self.elided = []
+    self.lines = []
+    self.raw_lines = lines
+    self.num_lines = len(lines)
+    self.lines_without_raw_strings = CleanseRawStrings(lines)
+    for linenum in range(len(self.lines_without_raw_strings)):
+      self.lines.append(CleanseComments(
+          self.lines_without_raw_strings[linenum]))
+      elided = self._CollapseStrings(self.lines_without_raw_strings[linenum])
+      self.elided.append(CleanseComments(elided))
+
+  def NumLines(self):
+    """Returns the number of lines represented."""
+    return self.num_lines
+
+  @staticmethod
+  def _CollapseStrings(elided):
+    """Collapses strings and chars on a line to simple "" or '' blocks.
+
+    We nix strings first so we're not fooled by text like '"http://"'
+
+    Args:
+      elided: The line being processed.
+
+    Returns:
+      The line with collapsed strings.
+    """
+    if _RE_PATTERN_INCLUDE.match(elided):
+      return elided
+
+    # Remove escaped characters first to make quote/single quote collapsing
+    # basic.  Things that look like escaped characters shouldn't occur
+    # outside of strings and chars.
+    elided = _RE_PATTERN_CLEANSE_LINE_ESCAPES.sub('', elided)
+
+    # Replace quoted strings and digit separators.  Both single quotes
+    # and double quotes are processed in the same loop, otherwise
+    # nested quotes wouldn't work.
+    collapsed = ''
+    while True:
+      # Find the first quote character
+      match = Match(r'^([^\'"]*)([\'"])(.*)$', elided)
+      if not match:
+        collapsed += elided
+        break
+      head, quote, tail = match.groups()
+
+      if quote == '"':
+        # Collapse double quoted strings
+        second_quote = tail.find('"')
+        if second_quote >= 0:
+          collapsed += head + '""'
+          elided = tail[second_quote + 1:]
+        else:
+          # Unmatched double quote, don't bother processing the rest
+          # of the line since this is probably a multiline string.
+          collapsed += elided
+          break
+      else:
+        # Found single quote, check nearby text to eliminate digit separators.
+        #
+        # There is no special handling for floating point here, because
+        # the integer/fractional/exponent parts would all be parsed
+        # correctly as long as there are digits on both sides of the
+        # separator.  So we are fine as long as we don't see something
+        # like "0.'3" (gcc 4.9.0 will not allow this literal).
+        if Search(r'\b(?:0[bBxX]?|[1-9])[0-9a-fA-F]*$', head):
+          match_literal = Match(r'^((?:\'?[0-9a-zA-Z_])*)(.*)$', "'" + tail)
+          collapsed += head + match_literal.group(1).replace("'", '')
+          elided = match_literal.group(2)
+        else:
+          second_quote = tail.find('\'')
+          if second_quote >= 0:
+            collapsed += head + "''"
+            elided = tail[second_quote + 1:]
+          else:
+            # Unmatched single quote
+            collapsed += elided
+            break
+
+    return collapsed
+
+
+def FindEndOfExpressionInLine(line, startpos, stack):
+  """Find the position just after the end of current parenthesized expression.
+
+  Args:
+    line: a CleansedLines line.
+    startpos: start searching at this position.
+    stack: nesting stack at startpos.
+
+  Returns:
+    On finding matching end: (index just after matching end, None)
+    On finding an unclosed expression: (-1, None)
+    Otherwise: (-1, new stack at end of this line)
+  """
+  for i in xrange(startpos, len(line)):
+    char = line[i]
+    if char in '([{':
+      # Found start of parenthesized expression, push to expression stack
+      stack.append(char)
+    elif char == '<':
+      # Found potential start of template argument list
+      if i > 0 and line[i - 1] == '<':
+        # Left shift operator
+        if stack and stack[-1] == '<':
+          stack.pop()
+          if not stack:
+            return (-1, None)
+      elif i > 0 and Search(r'\boperator\s*$', line[0:i]):
+        # operator<, don't add to stack
+        continue
+      else:
+        # Tentative start of template argument list
+        stack.append('<')
+    elif char in ')]}':
+      # Found end of parenthesized expression.
+      #
+      # If we are currently expecting a matching '>', the pending '<'
+      # must have been an operator.  Remove them from expression stack.
+      while stack and stack[-1] == '<':
+        stack.pop()
+      if not stack:
+        return (-1, None)
+      if ((stack[-1] == '(' and char == ')') or
+          (stack[-1] == '[' and char == ']') or
+          (stack[-1] == '{' and char == '}')):
+        stack.pop()
+        if not stack:
+          return (i + 1, None)
+      else:
+        # Mismatched parentheses
+        return (-1, None)
+    elif char == '>':
+      # Found potential end of template argument list.
+
+      # Ignore "->" and operator functions
+      if (i > 0 and
+          (line[i - 1] == '-' or Search(r'\boperator\s*$', line[0:i - 1]))):
+        continue
+
+      # Pop the stack if there is a matching '<'.  Otherwise, ignore
+      # this '>' since it must be an operator.
+      if stack:
+        if stack[-1] == '<':
+          stack.pop()
+          if not stack:
+            return (i + 1, None)
+    elif char == ';':
+      # Found something that look like end of statements.  If we are currently
+      # expecting a '>', the matching '<' must have been an operator, since
+      # template argument list should not contain statements.
+      while stack and stack[-1] == '<':
+        stack.pop()
+      if not stack:
+        return (-1, None)
+
+  # Did not find end of expression or unbalanced parentheses on this line
+  return (-1, stack)
+
+
+def CloseExpression(clean_lines, linenum, pos):
+  """If input points to ( or { or [ or <, finds the position that closes it.
+
+  If lines[linenum][pos] points to a '(' or '{' or '[' or '<', finds the
+  linenum/pos that correspond to the closing of the expression.
+
+  TODO(unknown): cpplint spends a fair bit of time matching parentheses.
+  Ideally we would want to index all opening and closing parentheses once
+  and have CloseExpression be just a simple lookup, but due to preprocessor
+  tricks, this is not so easy.
+
+  Args:
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    pos: A position on the line.
+
+  Returns:
+    A tuple (line, linenum, pos) pointer *past* the closing brace, or
+    (line, len(lines), -1) if we never find a close.  Note we ignore
+    strings and comments when matching; and the line we return is the
+    'cleansed' line at linenum.
+  """
+
+  line = clean_lines.elided[linenum]
+  if (line[pos] not in '({[<') or Match(r'<[<=]', line[pos:]):
+    return (line, clean_lines.NumLines(), -1)
+
+  # Check first line
+  (end_pos, stack) = FindEndOfExpressionInLine(line, pos, [])
+  if end_pos > -1:
+    return (line, linenum, end_pos)
+
+  # Continue scanning forward
+  while stack and linenum < clean_lines.NumLines() - 1:
+    linenum += 1
+    line = clean_lines.elided[linenum]
+    (end_pos, stack) = FindEndOfExpressionInLine(line, 0, stack)
+    if end_pos > -1:
+      return (line, linenum, end_pos)
+
+  # Did not find end of expression before end of file, give up
+  return (line, clean_lines.NumLines(), -1)
+
+
+def FindStartOfExpressionInLine(line, endpos, stack):
+  """Find position at the matching start of current expression.
+
+  This is almost the reverse of FindEndOfExpressionInLine, but note
+  that the input position and returned position differs by 1.
+
+  Args:
+    line: a CleansedLines line.
+    endpos: start searching at this position.
+    stack: nesting stack at endpos.
+
+  Returns:
+    On finding matching start: (index at matching start, None)
+    On finding an unclosed expression: (-1, None)
+    Otherwise: (-1, new stack at beginning of this line)
+  """
+  i = endpos
+  while i >= 0:
+    char = line[i]
+    if char in ')]}':
+      # Found end of expression, push to expression stack
+      stack.append(char)
+    elif char == '>':
+      # Found potential end of template argument list.
+      #
+      # Ignore it if it's a "->" or ">=" or "operator>"
+      if (i > 0 and
+          (line[i - 1] == '-' or
+           Match(r'\s>=\s', line[i - 1:]) or
+           Search(r'\boperator\s*$', line[0:i]))):
+        i -= 1
+      else:
+        stack.append('>')
+    elif char == '<':
+      # Found potential start of template argument list
+      if i > 0 and line[i - 1] == '<':
+        # Left shift operator
+        i -= 1
+      else:
+        # If there is a matching '>', we can pop the expression stack.
+        # Otherwise, ignore this '<' since it must be an operator.
+        if stack and stack[-1] == '>':
+          stack.pop()
+          if not stack:
+            return (i, None)
+    elif char in '([{':
+      # Found start of expression.
+      #
+      # If there are any unmatched '>' on the stack, they must be
+      # operators.  Remove those.
+      while stack and stack[-1] == '>':
+        stack.pop()
+      if not stack:
+        return (-1, None)
+      if ((char == '(' and stack[-1] == ')') or
+          (char == '[' and stack[-1] == ']') or
+          (char == '{' and stack[-1] == '}')):
+        stack.pop()
+        if not stack:
+          return (i, None)
+      else:
+        # Mismatched parentheses
+        return (-1, None)
+    elif char == ';':
+      # Found something that look like end of statements.  If we are currently
+      # expecting a '<', the matching '>' must have been an operator, since
+      # template argument list should not contain statements.
+      while stack and stack[-1] == '>':
+        stack.pop()
+      if not stack:
+        return (-1, None)
+
+    i -= 1
+
+  return (-1, stack)
+
+
+def ReverseCloseExpression(clean_lines, linenum, pos):
+  """If input points to ) or } or ] or >, finds the position that opens it.
+
+  If lines[linenum][pos] points to a ')' or '}' or ']' or '>', finds the
+  linenum/pos that correspond to the opening of the expression.
+
+  Args:
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    pos: A position on the line.
+
+  Returns:
+    A tuple (line, linenum, pos) pointer *at* the opening brace, or
+    (line, 0, -1) if we never find the matching opening brace.  Note
+    we ignore strings and comments when matching; and the line we
+    return is the 'cleansed' line at linenum.
+  """
+  line = clean_lines.elided[linenum]
+  if line[pos] not in ')}]>':
+    return (line, 0, -1)
+
+  # Check last line
+  (start_pos, stack) = FindStartOfExpressionInLine(line, pos, [])
+  if start_pos > -1:
+    return (line, linenum, start_pos)
+
+  # Continue scanning backward
+  while stack and linenum > 0:
+    linenum -= 1
+    line = clean_lines.elided[linenum]
+    (start_pos, stack) = FindStartOfExpressionInLine(line, len(line) - 1, stack)
+    if start_pos > -1:
+      return (line, linenum, start_pos)
+
+  # Did not find start of expression before beginning of file, give up
+  return (line, 0, -1)
+
+
+def CheckForCopyright(filename, lines, error):
+  """Logs an error if no Copyright message appears at the top of the file."""
+
+  # We'll say it should occur by line 10. Don't forget there's a
+  # dummy line at the front.
+  for line in xrange(1, min(len(lines), 11)):
+    if re.search(r'Copyright', lines[line], re.I): break
+  else:                       # means no copyright line was found
+    error(filename, 0, 'legal/copyright', 5,
+          'No copyright message found.  '
+          'You should have a line: "Copyright [year] <Copyright Owner>"')
+
+
+def GetIndentLevel(line):
+  """Return the number of leading spaces in line.
+
+  Args:
+    line: A string to check.
+
+  Returns:
+    An integer count of leading spaces, possibly zero.
+  """
+  indent = Match(r'^( *)\S', line)
+  if indent:
+    return len(indent.group(1))
+  else:
+    return 0
+
+
+def GetHeaderGuardCPPVariable(filename):
+  """Returns the CPP variable that should be used as a header guard.
+
+  Args:
+    filename: The name of a C++ header file.
+
+  Returns:
+    The CPP variable that should be used as a header guard in the
+    named file.
+
+  """
+
+  # Restores original filename in case that cpplint is invoked from Emacs's
+  # flymake.
+  filename = re.sub(r'_flymake\.h$', '.h', filename)
+  filename = re.sub(r'/\.flymake/([^/]*)$', r'/\1', filename)
+  # Replace 'c++' with 'cpp'.
+  filename = filename.replace('C++', 'cpp').replace('c++', 'cpp')
+  
+  fileinfo = FileInfo(filename)
+  file_path_from_root = fileinfo.RepositoryName()
+  if _root:
+    file_path_from_root = re.sub('^' + _root + os.sep, '', file_path_from_root)
+  return re.sub(r'[^a-zA-Z0-9]', '_', file_path_from_root).upper() + '_'
+
+
+def CheckForHeaderGuard(filename, clean_lines, error):
+  """Checks that the file contains a header guard.
+
+  Logs an error if no #ifndef header guard is present.  For other
+  headers, checks that the full pathname is used.
+
+  Args:
+    filename: The name of the C++ header file.
+    clean_lines: A CleansedLines instance containing the file.
+    error: The function to call with any errors found.
+  """
+
+  # Don't check for header guards if there are error suppression
+  # comments somewhere in this file.
+  #
+  # Because this is silencing a warning for a nonexistent line, we
+  # only support the very specific NOLINT(build/header_guard) syntax,
+  # and not the general NOLINT or NOLINT(*) syntax.
+  raw_lines = clean_lines.lines_without_raw_strings
+  for i in raw_lines:
+    if Search(r'//\s*NOLINT\(build/header_guard\)', i):
+      return
+
+  cppvar = GetHeaderGuardCPPVariable(filename)
+
+  ifndef = ''
+  ifndef_linenum = 0
+  define = ''
+  endif = ''
+  endif_linenum = 0
+  for linenum, line in enumerate(raw_lines):
+    linesplit = line.split()
+    if len(linesplit) >= 2:
+      # find the first occurrence of #ifndef and #define, save arg
+      if not ifndef and linesplit[0] == '#ifndef':
+        # set ifndef to the header guard presented on the #ifndef line.
+        ifndef = linesplit[1]
+        ifndef_linenum = linenum
+      if not define and linesplit[0] == '#define':
+        define = linesplit[1]
+    # find the last occurrence of #endif, save entire line
+    if line.startswith('#endif'):
+      endif = line
+      endif_linenum = linenum
+
+  if not ifndef or not define or ifndef != define:
+    error(filename, 0, 'build/header_guard', 5,
+          'No #ifndef header guard found, suggested CPP variable is: %s' %
+          cppvar)
+    return
+
+  # The guard should be PATH_FILE_H_, but we also allow PATH_FILE_H__
+  # for backward compatibility.
+  if ifndef != cppvar:
+    error_level = 0
+    if ifndef != cppvar + '_':
+      error_level = 5
+
+    ParseNolintSuppressions(filename, raw_lines[ifndef_linenum], ifndef_linenum,
+                            error)
+    error(filename, ifndef_linenum, 'build/header_guard', error_level,
+          '#ifndef header guard has wrong style, please use: %s' % cppvar)
+
+  # Check for "//" comments on endif line.
+  ParseNolintSuppressions(filename, raw_lines[endif_linenum], endif_linenum,
+                          error)
+  match = Match(r'#endif\s*//\s*' + cppvar + r'(_)?\b', endif)
+  if match:
+    if match.group(1) == '_':
+      # Issue low severity warning for deprecated double trailing underscore
+      error(filename, endif_linenum, 'build/header_guard', 0,
+            '#endif line should be "#endif  // %s"' % cppvar)
+    return
+
+  # Didn't find the corresponding "//" comment.  If this file does not
+  # contain any "//" comments at all, it could be that the compiler
+  # only wants "/**/" comments, look for those instead.
+  no_single_line_comments = True
+  for i in xrange(1, len(raw_lines) - 1):
+    line = raw_lines[i]
+    if Match(r'^(?:(?:\'(?:\.|[^\'])*\')|(?:"(?:\.|[^"])*")|[^\'"])*//', line):
+      no_single_line_comments = False
+      break
+
+  if no_single_line_comments:
+    match = Match(r'#endif\s*/\*\s*' + cppvar + r'(_)?\s*\*/', endif)
+    if match:
+      if match.group(1) == '_':
+        # Low severity warning for double trailing underscore
+        error(filename, endif_linenum, 'build/header_guard', 0,
+              '#endif line should be "#endif  /* %s */"' % cppvar)
+      return
+
+  # Didn't find anything
+  error(filename, endif_linenum, 'build/header_guard', 5,
+        '#endif line should be "#endif  // %s"' % cppvar)
+
+
+def CheckHeaderFileIncluded(filename, include_state, error):
+  """Logs an error if a .cc file does not include its header."""
+
+  # Do not check test files
+  if filename.endswith('_test.cc') or filename.endswith('_unittest.cc'):
+    return
+
+  fileinfo = FileInfo(filename)
+  headerfile = filename[0:len(filename) - 2] + 'h'
+  if not os.path.exists(headerfile):
+    return
+  headername = FileInfo(headerfile).RepositoryName()
+  first_include = 0
+  for section_list in include_state.include_list:
+    for f in section_list:
+      if headername in f[0] or f[0] in headername:
+        return
+      if not first_include:
+        first_include = f[1]
+
+  error(filename, first_include, 'build/include', 5,
+        '%s should include its header file %s' % (fileinfo.RepositoryName(),
+                                                  headername))
+
+
+def CheckForBadCharacters(filename, lines, error):
+  """Logs an error for each line containing bad characters.
+
+  Two kinds of bad characters:
+
+  1. Unicode replacement characters: These indicate that either the file
+  contained invalid UTF-8 (likely) or Unicode replacement characters (which
+  it shouldn't).  Note that it's possible for this to throw off line
+  numbering if the invalid UTF-8 occurred adjacent to a newline.
+
+  2. NUL bytes.  These are problematic for some tools.
+
+  Args:
+    filename: The name of the current file.
+    lines: An array of strings, each representing a line of the file.
+    error: The function to call with any errors found.
+  """
+  for linenum, line in enumerate(lines):
+    if u'\ufffd' in line:
+      error(filename, linenum, 'readability/utf8', 5,
+            'Line contains invalid UTF-8 (or Unicode replacement character).')
+    if '\0' in line:
+      error(filename, linenum, 'readability/nul', 5, 'Line contains NUL byte.')
+
+
+def CheckForNewlineAtEOF(filename, lines, error):
+  """Logs an error if there is no newline char at the end of the file.
+
+  Args:
+    filename: The name of the current file.
+    lines: An array of strings, each representing a line of the file.
+    error: The function to call with any errors found.
+  """
+
+  # The array lines() was created by adding two newlines to the
+  # original file (go figure), then splitting on \n.
+  # To verify that the file ends in \n, we just have to make sure the
+  # last-but-two element of lines() exists and is empty.
+  if len(lines) < 3 or lines[-2]:
+    error(filename, len(lines) - 2, 'whitespace/ending_newline', 5,
+          'Could not find a newline character at the end of the file.')
+
+
+def CheckForMultilineCommentsAndStrings(filename, clean_lines, linenum, error):
+  """Logs an error if we see /* ... */ or "..." that extend past one line.
+
+  /* ... */ comments are legit inside macros, for one line.
+  Otherwise, we prefer // comments, so it's ok to warn about the
+  other.  Likewise, it's ok for strings to extend across multiple
+  lines, as long as a line continuation character (backslash)
+  terminates each line. Although not currently prohibited by the C++
+  style guide, it's ugly and unnecessary. We don't do well with either
+  in this lint program, so we warn about both.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    error: The function to call with any errors found.
+  """
+  line = clean_lines.elided[linenum]
+
+  # Remove all \\ (escaped backslashes) from the line. They are OK, and the
+  # second (escaped) slash may trigger later \" detection erroneously.
+  line = line.replace('\\\\', '')
+
+  if line.count('/*') > line.count('*/'):
+    error(filename, linenum, 'readability/multiline_comment', 5,
+          'Complex multi-line /*...*/-style comment found. '
+          'Lint may give bogus warnings.  '
+          'Consider replacing these with //-style comments, '
+          'with #if 0...#endif, '
+          'or with more clearly structured multi-line comments.')
+
+  if (line.count('"') - line.count('\\"')) % 2:
+    error(filename, linenum, 'readability/multiline_string', 5,
+          'Multi-line string ("...") found.  This lint script doesn\'t '
+          'do well with such strings, and may give bogus warnings.  '
+          'Use C++11 raw strings or concatenation instead.')
+
+
+# (non-threadsafe name, thread-safe alternative, validation pattern)
+#
+# The validation pattern is used to eliminate false positives such as:
+#  _rand();               // false positive due to substring match.
+#  ->rand();              // some member function rand().
+#  ACMRandom rand(seed);  // some variable named rand.
+#  ISAACRandom rand();    // another variable named rand.
+#
+# Basically we require the return value of these functions to be used
+# in some expression context on the same line by matching on some
+# operator before the function name.  This eliminates constructors and
+# member function calls.
+_UNSAFE_FUNC_PREFIX = r'(?:[-+*/=%^&|(<]\s*|>\s+)'
+_THREADING_LIST = (
+    ('asctime(', 'asctime_r(', _UNSAFE_FUNC_PREFIX + r'asctime\([^)]+\)'),
+    ('ctime(', 'ctime_r(', _UNSAFE_FUNC_PREFIX + r'ctime\([^)]+\)'),
+    ('getgrgid(', 'getgrgid_r(', _UNSAFE_FUNC_PREFIX + r'getgrgid\([^)]+\)'),
+    ('getgrnam(', 'getgrnam_r(', _UNSAFE_FUNC_PREFIX + r'getgrnam\([^)]+\)'),
+    ('getlogin(', 'getlogin_r(', _UNSAFE_FUNC_PREFIX + r'getlogin\(\)'),
+    ('getpwnam(', 'getpwnam_r(', _UNSAFE_FUNC_PREFIX + r'getpwnam\([^)]+\)'),
+    ('getpwuid(', 'getpwuid_r(', _UNSAFE_FUNC_PREFIX + r'getpwuid\([^)]+\)'),
+    ('gmtime(', 'gmtime_r(', _UNSAFE_FUNC_PREFIX + r'gmtime\([^)]+\)'),
+    ('localtime(', 'localtime_r(', _UNSAFE_FUNC_PREFIX + r'localtime\([^)]+\)'),
+    ('rand(', 'rand_r(', _UNSAFE_FUNC_PREFIX + r'rand\(\)'),
+    ('strtok(', 'strtok_r(',
+     _UNSAFE_FUNC_PREFIX + r'strtok\([^)]+\)'),
+    ('ttyname(', 'ttyname_r(', _UNSAFE_FUNC_PREFIX + r'ttyname\([^)]+\)'),
+    )
+
+
+def CheckPosixThreading(filename, clean_lines, linenum, error):
+  """Checks for calls to thread-unsafe functions.
+
+  Much code has been originally written without consideration of
+  multi-threading. Also, engineers are relying on their old experience;
+  they have learned posix before threading extensions were added. These
+  tests guide the engineers to use thread-safe functions (when using
+  posix directly).
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    error: The function to call with any errors found.
+  """
+  line = clean_lines.elided[linenum]
+  for single_thread_func, multithread_safe_func, pattern in _THREADING_LIST:
+    # Additional pattern matching check to confirm that this is the
+    # function we are looking for
+    if Search(pattern, line):
+      error(filename, linenum, 'runtime/threadsafe_fn', 2,
+            'Consider using ' + multithread_safe_func +
+            '...) instead of ' + single_thread_func +
+            '...) for improved thread safety.')
+
+
+def CheckVlogArguments(filename, clean_lines, linenum, error):
+  """Checks that VLOG() is only used for defining a logging level.
+
+  For example, VLOG(2) is correct. VLOG(INFO), VLOG(WARNING), VLOG(ERROR), and
+  VLOG(FATAL) are not.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    error: The function to call with any errors found.
+  """
+  line = clean_lines.elided[linenum]
+  if Search(r'\bVLOG\((INFO|ERROR|WARNING|DFATAL|FATAL)\)', line):
+    error(filename, linenum, 'runtime/vlog', 5,
+          'VLOG() should be used with numeric verbosity level.  '
+          'Use LOG() if you want symbolic severity levels.')
+
+# Matches invalid increment: *count++, which moves pointer instead of
+# incrementing a value.
+_RE_PATTERN_INVALID_INCREMENT = re.compile(
+    r'^\s*\*\w+(\+\+|--);')
+
+
+def CheckInvalidIncrement(filename, clean_lines, linenum, error):
+  """Checks for invalid increment *count++.
+
+  For example following function:
+  void increment_counter(int* count) {
+    *count++;
+  }
+  is invalid, because it effectively does count++, moving pointer, and should
+  be replaced with ++*count, (*count)++ or *count += 1.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    error: The function to call with any errors found.
+  """
+  line = clean_lines.elided[linenum]
+  if _RE_PATTERN_INVALID_INCREMENT.match(line):
+    error(filename, linenum, 'runtime/invalid_increment', 5,
+          'Changing pointer instead of value (or unused value of operator*).')
+
+
+def IsMacroDefinition(clean_lines, linenum):
+  if Search(r'^#define', clean_lines[linenum]):
+    return True
+
+  if linenum > 0 and Search(r'\\$', clean_lines[linenum - 1]):
+    return True
+
+  return False
+
+
+def IsForwardClassDeclaration(clean_lines, linenum):
+  return Match(r'^\s*(\btemplate\b)*.*class\s+\w+;\s*$', clean_lines[linenum])
+
+
+class _BlockInfo(object):
+  """Stores information about a generic block of code."""
+
+  def __init__(self, seen_open_brace):
+    self.seen_open_brace = seen_open_brace
+    self.open_parentheses = 0
+    self.inline_asm = _NO_ASM
+    self.check_namespace_indentation = False
+
+  def CheckBegin(self, filename, clean_lines, linenum, error):
+    """Run checks that applies to text up to the opening brace.
+
+    This is mostly for checking the text after the class identifier
+    and the "{", usually where the base class is specified.  For other
+    blocks, there isn't much to check, so we always pass.
+
+    Args:
+      filename: The name of the current file.
+      clean_lines: A CleansedLines instance containing the file.
+      linenum: The number of the line to check.
+      error: The function to call with any errors found.
+    """
+    pass
+
+  def CheckEnd(self, filename, clean_lines, linenum, error):
+    """Run checks that applies to text after the closing brace.
+
+    This is mostly used for checking end of namespace comments.
+
+    Args:
+      filename: The name of the current file.
+      clean_lines: A CleansedLines instance containing the file.
+      linenum: The number of the line to check.
+      error: The function to call with any errors found.
+    """
+    pass
+
+  def IsBlockInfo(self):
+    """Returns true if this block is a _BlockInfo.
+
+    This is convenient for verifying that an object is an instance of
+    a _BlockInfo, but not an instance of any of the derived classes.
+
+    Returns:
+      True for this class, False for derived classes.
+    """
+    return self.__class__ == _BlockInfo
+
+
+class _ExternCInfo(_BlockInfo):
+  """Stores information about an 'extern "C"' block."""
+
+  def __init__(self):
+    _BlockInfo.__init__(self, True)
+
+
+class _ClassInfo(_BlockInfo):
+  """Stores information about a class."""
+
+  def __init__(self, name, class_or_struct, clean_lines, linenum):
+    _BlockInfo.__init__(self, False)
+    self.name = name
+    self.starting_linenum = linenum
+    self.is_derived = False
+    self.check_namespace_indentation = True
+    if class_or_struct == 'struct':
+      self.access = 'public'
+      self.is_struct = True
+    else:
+      self.access = 'private'
+      self.is_struct = False
+
+    # Remember initial indentation level for this class.  Using raw_lines here
+    # instead of elided to account for leading comments.
+    self.class_indent = GetIndentLevel(clean_lines.raw_lines[linenum])
+
+    # Try to find the end of the class.  This will be confused by things like:
+    #   class A {
+    #   } *x = { ...
+    #
+    # But it's still good enough for CheckSectionSpacing.
+    self.last_line = 0
+    depth = 0
+    for i in range(linenum, clean_lines.NumLines()):
+      line = clean_lines.elided[i]
+      depth += line.count('{') - line.count('}')
+      if not depth:
+        self.last_line = i
+        break
+
+  def CheckBegin(self, filename, clean_lines, linenum, error):
+    # Look for a bare ':'
+    if Search('(^|[^:]):($|[^:])', clean_lines.elided[linenum]):
+      self.is_derived = True
+
+  def CheckEnd(self, filename, clean_lines, linenum, error):
+    # If there is a DISALLOW macro, it should appear near the end of
+    # the class.
+    seen_last_thing_in_class = False
+    for i in xrange(linenum - 1, self.starting_linenum, -1):
+      match = Search(
+          r'\b(DISALLOW_COPY_AND_ASSIGN|DISALLOW_IMPLICIT_CONSTRUCTORS)\(' +
+          self.name + r'\)',
+          clean_lines.elided[i])
+      if match:
+        if seen_last_thing_in_class:
+          error(filename, i, 'readability/constructors', 3,
+                match.group(1) + ' should be the last thing in the class')
+        break
+
+      if not Match(r'^\s*$', clean_lines.elided[i]):
+        seen_last_thing_in_class = True
+
+    # Check that closing brace is aligned with beginning of the class.
+    # Only do this if the closing brace is indented by only whitespaces.
+    # This means we will not check single-line class definitions.
+    indent = Match(r'^( *)\}', clean_lines.elided[linenum])
+    if indent and len(indent.group(1)) != self.class_indent:
+      if self.is_struct:
+        parent = 'struct ' + self.name
+      else:
+        parent = 'class ' + self.name
+      error(filename, linenum, 'whitespace/indent', 3,
+            'Closing brace should be aligned with beginning of %s' % parent)
+
+
+class _NamespaceInfo(_BlockInfo):
+  """Stores information about a namespace."""
+
+  def __init__(self, name, linenum):
+    _BlockInfo.__init__(self, False)
+    self.name = name or ''
+    self.starting_linenum = linenum
+    self.check_namespace_indentation = True
+
+  def CheckEnd(self, filename, clean_lines, linenum, error):
+    """Check end of namespace comments."""
+    line = clean_lines.raw_lines[linenum]
+
+    # Check how many lines is enclosed in this namespace.  Don't issue
+    # warning for missing namespace comments if there aren't enough
+    # lines.  However, do apply checks if there is already an end of
+    # namespace comment and it's incorrect.
+    #
+    # TODO(unknown): We always want to check end of namespace comments
+    # if a namespace is large, but sometimes we also want to apply the
+    # check if a short namespace contained nontrivial things (something
+    # other than forward declarations).  There is currently no logic on
+    # deciding what these nontrivial things are, so this check is
+    # triggered by namespace size only, which works most of the time.
+    if (linenum - self.starting_linenum < 10
+        and not Match(r'};*\s*(//|/\*).*\bnamespace\b', line)):
+      return
+
+    # Look for matching comment at end of namespace.
+    #
+    # Note that we accept C style "/* */" comments for terminating
+    # namespaces, so that code that terminate namespaces inside
+    # preprocessor macros can be cpplint clean.
+    #
+    # We also accept stuff like "// end of namespace <name>." with the
+    # period at the end.
+    #
+    # Besides these, we don't accept anything else, otherwise we might
+    # get false negatives when existing comment is a substring of the
+    # expected namespace.
+    if self.name:
+      # Named namespace
+      if not Match((r'};*\s*(//|/\*).*\bnamespace\s+' + re.escape(self.name) +
+                    r'[\*/\.\\\s]*$'),
+                   line):
+        error(filename, linenum, 'readability/namespace', 5,
+              'Namespace should be terminated with "// namespace %s"' %
+              self.name)
+    else:
+      # Anonymous namespace
+      if not Match(r'};*\s*(//|/\*).*\bnamespace[\*/\.\\\s]*$', line):
+        # If "// namespace anonymous" or "// anonymous namespace (more text)",
+        # mention "// anonymous namespace" as an acceptable form
+        if Match(r'}.*\b(namespace anonymous|anonymous namespace)\b', line):
+          error(filename, linenum, 'readability/namespace', 5,
+                'Anonymous namespace should be terminated with "// namespace"'
+                ' or "// anonymous namespace"')
+        else:
+          error(filename, linenum, 'readability/namespace', 5,
+                'Anonymous namespace should be terminated with "// namespace"')
+
+
+class _PreprocessorInfo(object):
+  """Stores checkpoints of nesting stacks when #if/#else is seen."""
+
+  def __init__(self, stack_before_if):
+    # The entire nesting stack before #if
+    self.stack_before_if = stack_before_if
+
+    # The entire nesting stack up to #else
+    self.stack_before_else = []
+
+    # Whether we have already seen #else or #elif
+    self.seen_else = False
+
+
+class NestingState(object):
+  """Holds states related to parsing braces."""
+
+  def __init__(self):
+    # Stack for tracking all braces.  An object is pushed whenever we
+    # see a "{", and popped when we see a "}".  Only 3 types of
+    # objects are possible:
+    # - _ClassInfo: a class or struct.
+    # - _NamespaceInfo: a namespace.
+    # - _BlockInfo: some other type of block.
+    self.stack = []
+
+    # Top of the previous stack before each Update().
+    #
+    # Because the nesting_stack is updated at the end of each line, we
+    # had to do some convoluted checks to find out what is the current
+    # scope at the beginning of the line.  This check is simplified by
+    # saving the previous top of nesting stack.
+    #
+    # We could save the full stack, but we only need the top.  Copying
+    # the full nesting stack would slow down cpplint by ~10%.
+    self.previous_stack_top = []
+
+    # Stack of _PreprocessorInfo objects.
+    self.pp_stack = []
+
+  def SeenOpenBrace(self):
+    """Check if we have seen the opening brace for the innermost block.
+
+    Returns:
+      True if we have seen the opening brace, False if the innermost
+      block is still expecting an opening brace.
+    """
+    return (not self.stack) or self.stack[-1].seen_open_brace
+
+  def InNamespaceBody(self):
+    """Check if we are currently one level inside a namespace body.
+
+    Returns:
+      True if top of the stack is a namespace block, False otherwise.
+    """
+    return self.stack and isinstance(self.stack[-1], _NamespaceInfo)
+
+  def InExternC(self):
+    """Check if we are currently one level inside an 'extern "C"' block.
+
+    Returns:
+      True if top of the stack is an extern block, False otherwise.
+    """
+    return self.stack and isinstance(self.stack[-1], _ExternCInfo)
+
+  def InClassDeclaration(self):
+    """Check if we are currently one level inside a class or struct declaration.
+
+    Returns:
+      True if top of the stack is a class/struct, False otherwise.
+    """
+    return self.stack and isinstance(self.stack[-1], _ClassInfo)
+
+  def InAsmBlock(self):
+    """Check if we are currently one level inside an inline ASM block.
+
+    Returns:
+      True if the top of the stack is a block containing inline ASM.
+    """
+    return self.stack and self.stack[-1].inline_asm != _NO_ASM
+
+  def InTemplateArgumentList(self, clean_lines, linenum, pos):
+    """Check if current position is inside template argument list.
+
+    Args:
+      clean_lines: A CleansedLines instance containing the file.
+      linenum: The number of the line to check.
+      pos: position just after the suspected template argument.
+    Returns:
+      True if (linenum, pos) is inside template arguments.
+    """
+    while linenum < clean_lines.NumLines():
+      # Find the earliest character that might indicate a template argument
+      line = clean_lines.elided[linenum]
+      match = Match(r'^[^{};=\[\]\.<>]*(.)', line[pos:])
+      if not match:
+        linenum += 1
+        pos = 0
+        continue
+      token = match.group(1)
+      pos += len(match.group(0))
+
+      # These things do not look like template argument list:
+      #   class Suspect {
+      #   class Suspect x; }
+      if token in ('{', '}', ';'): return False
+
+      # These things look like template argument list:
+      #   template <class Suspect>
+      #   template <class Suspect = default_value>
+      #   template <class Suspect[]>
+      #   template <class Suspect...>
+      if token in ('>', '=', '[', ']', '.'): return True
+
+      # Check if token is an unmatched '<'.
+      # If not, move on to the next character.
+      if token != '<':
+        pos += 1
+        if pos >= len(line):
+          linenum += 1
+          pos = 0
+        continue
+
+      # We can't be sure if we just find a single '<', and need to
+      # find the matching '>'.
+      (_, end_line, end_pos) = CloseExpression(clean_lines, linenum, pos - 1)
+      if end_pos < 0:
+        # Not sure if template argument list or syntax error in file
+        return False
+      linenum = end_line
+      pos = end_pos
+    return False
+
+  def UpdatePreprocessor(self, line):
+    """Update preprocessor stack.
+
+    We need to handle preprocessors due to classes like this:
+      #ifdef SWIG
+      struct ResultDetailsPageElementExtensionPoint {
+      #else
+      struct ResultDetailsPageElementExtensionPoint : public Extension {
+      #endif
+
+    We make the following assumptions (good enough for most files):
+    - Preprocessor condition evaluates to true from #if up to first
+      #else/#elif/#endif.
+
+    - Preprocessor condition evaluates to false from #else/#elif up
+      to #endif.  We still perform lint checks on these lines, but
+      these do not affect nesting stack.
+
+    Args:
+      line: current line to check.
+    """
+    if Match(r'^\s*#\s*(if|ifdef|ifndef)\b', line):
+      # Beginning of #if block, save the nesting stack here.  The saved
+      # stack will allow us to restore the parsing state in the #else case.
+      self.pp_stack.append(_PreprocessorInfo(copy.deepcopy(self.stack)))
+    elif Match(r'^\s*#\s*(else|elif)\b', line):
+      # Beginning of #else block
+      if self.pp_stack:
+        if not self.pp_stack[-1].seen_else:
+          # This is the first #else or #elif block.  Remember the
+          # whole nesting stack up to this point.  This is what we
+          # keep after the #endif.
+          self.pp_stack[-1].seen_else = True
+          self.pp_stack[-1].stack_before_else = copy.deepcopy(self.stack)
+
+        # Restore the stack to how it was before the #if
+        self.stack = copy.deepcopy(self.pp_stack[-1].stack_before_if)
+      else:
+        # TODO(unknown): unexpected #else, issue warning?
+        pass
+    elif Match(r'^\s*#\s*endif\b', line):
+      # End of #if or #else blocks.
+      if self.pp_stack:
+        # If we saw an #else, we will need to restore the nesting
+        # stack to its former state before the #else, otherwise we
+        # will just continue from where we left off.
+        if self.pp_stack[-1].seen_else:
+          # Here we can just use a shallow copy since we are the last
+          # reference to it.
+          self.stack = self.pp_stack[-1].stack_before_else
+        # Drop the corresponding #if
+        self.pp_stack.pop()
+      else:
+        # TODO(unknown): unexpected #endif, issue warning?
+        pass
+
+  # TODO(unknown): Update() is too long, but we will refactor later.
+  def Update(self, filename, clean_lines, linenum, error):
+    """Update nesting state with current line.
+
+    Args:
+      filename: The name of the current file.
+      clean_lines: A CleansedLines instance containing the file.
+      linenum: The number of the line to check.
+      error: The function to call with any errors found.
+    """
+    line = clean_lines.elided[linenum]
+
+    # Remember top of the previous nesting stack.
+    #
+    # The stack is always pushed/popped and not modified in place, so
+    # we can just do a shallow copy instead of copy.deepcopy.  Using
+    # deepcopy would slow down cpplint by ~28%.
+    if self.stack:
+      self.previous_stack_top = self.stack[-1]
+    else:
+      self.previous_stack_top = None
+
+    # Update pp_stack
+    self.UpdatePreprocessor(line)
+
+    # Count parentheses.  This is to avoid adding struct arguments to
+    # the nesting stack.
+    if self.stack:
+      inner_block = self.stack[-1]
+      depth_change = line.count('(') - line.count(')')
+      inner_block.open_parentheses += depth_change
+
+      # Also check if we are starting or ending an inline assembly block.
+      if inner_block.inline_asm in (_NO_ASM, _END_ASM):
+        if (depth_change != 0 and
+            inner_block.open_parentheses == 1 and
+            _MATCH_ASM.match(line)):
+          # Enter assembly block
+          inner_block.inline_asm = _INSIDE_ASM
+        else:
+          # Not entering assembly block.  If previous line was _END_ASM,
+          # we will now shift to _NO_ASM state.
+          inner_block.inline_asm = _NO_ASM
+      elif (inner_block.inline_asm == _INSIDE_ASM and
+            inner_block.open_parentheses == 0):
+        # Exit assembly block
+        inner_block.inline_asm = _END_ASM
+
+    # Consume namespace declaration at the beginning of the line.  Do
+    # this in a loop so that we catch same line declarations like this:
+    #   namespace proto2 { namespace bridge { class MessageSet; } }
+    while True:
+      # Match start of namespace.  The "\b\s*" below catches namespace
+      # declarations even if it weren't followed by a whitespace, this
+      # is so that we don't confuse our namespace checker.  The
+      # missing spaces will be flagged by CheckSpacing.
+      namespace_decl_match = Match(r'^\s*namespace\b\s*([:\w]+)?(.*)$', line)
+      if not namespace_decl_match:
+        break
+
+      new_namespace = _NamespaceInfo(namespace_decl_match.group(1), linenum)
+      self.stack.append(new_namespace)
+
+      line = namespace_decl_match.group(2)
+      if line.find('{') != -1:
+        new_namespace.seen_open_brace = True
+        line = line[line.find('{') + 1:]
+
+    # Look for a class declaration in whatever is left of the line
+    # after parsing namespaces.  The regexp accounts for decorated classes
+    # such as in:
+    #   class LOCKABLE API Object {
+    #   };
+    class_decl_match = Match(
+        r'^(\s*(?:template\s*<[\w\s<>,:]*>\s*)?'
+        r'(class|struct)\s+(?:[A-Z_]+\s+)*(\w+(?:::\w+)*))'
+        r'(.*)$', line)
+    if (class_decl_match and
+        (not self.stack or self.stack[-1].open_parentheses == 0)):
+      # We do not want to accept classes that are actually template arguments:
+      #   template <class Ignore1,
+      #             class Ignore2 = Default<Args>,
+      #             template <Args> class Ignore3>
+      #   void Function() {};
+      #
+      # To avoid template argument cases, we scan forward and look for
+      # an unmatched '>'.  If we see one, assume we are inside a
+      # template argument list.
+      end_declaration = len(class_decl_match.group(1))
+      if not self.InTemplateArgumentList(clean_lines, linenum, end_declaration):
+        self.stack.append(_ClassInfo(
+            class_decl_match.group(3), class_decl_match.group(2),
+            clean_lines, linenum))
+        line = class_decl_match.group(4)
+
+    # If we have not yet seen the opening brace for the innermost block,
+    # run checks here.
+    if not self.SeenOpenBrace():
+      self.stack[-1].CheckBegin(filename, clean_lines, linenum, error)
+
+    # Update access control if we are inside a class/struct
+    if self.stack and isinstance(self.stack[-1], _ClassInfo):
+      classinfo = self.stack[-1]
+      access_match = Match(
+          r'^(.*)\b(public|private|protected|signals)(\s+(?:slots\s*)?)?'
+          r':(?:[^:]|$)',
+          line)
+      if access_match:
+        classinfo.access = access_match.group(2)
+
+        # Check that access keywords are indented +1 space.  Skip this
+        # check if the keywords are not preceded by whitespaces.
+        indent = access_match.group(1)
+        if (len(indent) != classinfo.class_indent + 1 and
+            Match(r'^\s*$', indent)):
+          if classinfo.is_struct:
+            parent = 'struct ' + classinfo.name
+          else:
+            parent = 'class ' + classinfo.name
+          slots = ''
+          if access_match.group(3):
+            slots = access_match.group(3)
+          error(filename, linenum, 'whitespace/indent', 3,
+                '%s%s: should be indented +1 space inside %s' % (
+                    access_match.group(2), slots, parent))
+
+    # Consume braces or semicolons from what's left of the line
+    while True:
+      # Match first brace, semicolon, or closed parenthesis.
+      matched = Match(r'^[^{;)}]*([{;)}])(.*)$', line)
+      if not matched:
+        break
+
+      token = matched.group(1)
+      if token == '{':
+        # If namespace or class hasn't seen a opening brace yet, mark
+        # namespace/class head as complete.  Push a new block onto the
+        # stack otherwise.
+        if not self.SeenOpenBrace():
+          self.stack[-1].seen_open_brace = True
+        elif Match(r'^extern\s*"[^"]*"\s*\{', line):
+          self.stack.append(_ExternCInfo())
+        else:
+          self.stack.append(_BlockInfo(True))
+          if _MATCH_ASM.match(line):
+            self.stack[-1].inline_asm = _BLOCK_ASM
+
+      elif token == ';' or token == ')':
+        # If we haven't seen an opening brace yet, but we already saw
+        # a semicolon, this is probably a forward declaration.  Pop
+        # the stack for these.
+        #
+        # Similarly, if we haven't seen an opening brace yet, but we
+        # already saw a closing parenthesis, then these are probably
+        # function arguments with extra "class" or "struct" keywords.
+        # Also pop these stack for these.
+        if not self.SeenOpenBrace():
+          self.stack.pop()
+      else:  # token == '}'
+        # Perform end of block checks and pop the stack.
+        if self.stack:
+          self.stack[-1].CheckEnd(filename, clean_lines, linenum, error)
+          self.stack.pop()
+      line = matched.group(2)
+
+  def InnermostClass(self):
+    """Get class info on the top of the stack.
+
+    Returns:
+      A _ClassInfo object if we are inside a class, or None otherwise.
+    """
+    for i in range(len(self.stack), 0, -1):
+      classinfo = self.stack[i - 1]
+      if isinstance(classinfo, _ClassInfo):
+        return classinfo
+    return None
+
+  def CheckCompletedBlocks(self, filename, error):
+    """Checks that all classes and namespaces have been completely parsed.
+
+    Call this when all lines in a file have been processed.
+    Args:
+      filename: The name of the current file.
+      error: The function to call with any errors found.
+    """
+    # Note: This test can result in false positives if #ifdef constructs
+    # get in the way of brace matching. See the testBuildClass test in
+    # cpplint_unittest.py for an example of this.
+    for obj in self.stack:
+      if isinstance(obj, _ClassInfo):
+        error(filename, obj.starting_linenum, 'build/class', 5,
+              'Failed to find complete declaration of class %s' %
+              obj.name)
+      elif isinstance(obj, _NamespaceInfo):
+        error(filename, obj.starting_linenum, 'build/namespaces', 5,
+              'Failed to find complete declaration of namespace %s' %
+              obj.name)
+
+
+def CheckForNonStandardConstructs(filename, clean_lines, linenum,
+                                  nesting_state, error):
+  r"""Logs an error if we see certain non-ANSI constructs ignored by gcc-2.
+
+  Complain about several constructs which gcc-2 accepts, but which are
+  not standard C++.  Warning about these in lint is one way to ease the
+  transition to new compilers.
+  - put storage class first (e.g. "static const" instead of "const static").
+  - "%lld" instead of %qd" in printf-type functions.
+  - "%1$d" is non-standard in printf-type functions.
+  - "\%" is an undefined character escape sequence.
+  - text after #endif is not allowed.
+  - invalid inner-style forward declaration.
+  - >? and <? operators, and their >?= and <?= cousins.
+
+  Additionally, check for constructor/destructor style violations and reference
+  members, as it is very convenient to do so while checking for
+  gcc-2 compliance.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    nesting_state: A NestingState instance which maintains information about
+                   the current stack of nested blocks being parsed.
+    error: A callable to which errors are reported, which takes 4 arguments:
+           filename, line number, error level, and message
+  """
+
+  # Remove comments from the line, but leave in strings for now.
+  line = clean_lines.lines[linenum]
+
+  if Search(r'printf\s*\(.*".*%[-+ ]?\d*q', line):
+    error(filename, linenum, 'runtime/printf_format', 3,
+          '%q in format strings is deprecated.  Use %ll instead.')
+
+  if Search(r'printf\s*\(.*".*%\d+\$', line):
+    error(filename, linenum, 'runtime/printf_format', 2,
+          '%N$ formats are unconventional.  Try rewriting to avoid them.')
+
+  # Remove escaped backslashes before looking for undefined escapes.
+  line = line.replace('\\\\', '')
+
+  if Search(r'("|\').*\\(%|\[|\(|{)', line):
+    error(filename, linenum, 'build/printf_format', 3,
+          '%, [, (, and { are undefined character escapes.  Unescape them.')
+
+  # For the rest, work with both comments and strings removed.
+  line = clean_lines.elided[linenum]
+
+  if Search(r'\b(const|volatile|void|char|short|int|long'
+            r'|float|double|signed|unsigned'
+            r'|schar|u?int8|u?int16|u?int32|u?int64)'
+            r'\s+(register|static|extern|typedef)\b',
+            line):
+    error(filename, linenum, 'build/storage_class', 5,
+          'Storage class (static, extern, typedef, etc) should be first.')
+
+  if Match(r'\s*#\s*endif\s*[^/\s]+', line):
+    error(filename, linenum, 'build/endif_comment', 5,
+          'Uncommented text after #endif is non-standard.  Use a comment.')
+
+  if Match(r'\s*class\s+(\w+\s*::\s*)+\w+\s*;', line):
+    error(filename, linenum, 'build/forward_decl', 5,
+          'Inner-style forward declarations are invalid.  Remove this line.')
+
+  if Search(r'(\w+|[+-]?\d+(\.\d*)?)\s*(<|>)\?=?\s*(\w+|[+-]?\d+)(\.\d*)?',
+            line):
+    error(filename, linenum, 'build/deprecated', 3,
+          '>? and <? (max and min) operators are non-standard and deprecated.')
+
+  if Search(r'^\s*const\s*string\s*&\s*\w+\s*;', line):
+    # TODO(unknown): Could it be expanded safely to arbitrary references,
+    # without triggering too many false positives? The first
+    # attempt triggered 5 warnings for mostly benign code in the regtest, hence
+    # the restriction.
+    # Here's the original regexp, for the reference:
+    # type_name = r'\w+((\s*::\s*\w+)|(\s*<\s*\w+?\s*>))?'
+    # r'\s*const\s*' + type_name + '\s*&\s*\w+\s*;'
+    error(filename, linenum, 'runtime/member_string_references', 2,
+          'const string& members are dangerous. It is much better to use '
+          'alternatives, such as pointers or simple constants.')
+
+  # Everything else in this function operates on class declarations.
+  # Return early if the top of the nesting stack is not a class, or if
+  # the class head is not completed yet.
+  classinfo = nesting_state.InnermostClass()
+  if not classinfo or not classinfo.seen_open_brace:
+    return
+
+  # The class may have been declared with namespace or classname qualifiers.
+  # The constructor and destructor will not have those qualifiers.
+  base_classname = classinfo.name.split('::')[-1]
+
+  # Look for single-argument constructors that aren't marked explicit.
+  # Technically a valid construct, but against style. Also look for
+  # non-single-argument constructors which are also technically valid, but
+  # strongly suggest something is wrong.
+  explicit_constructor_match = Match(
+      r'\s+(?:inline\s+)?(explicit\s+)?(?:inline\s+)?%s\s*'
+      r'\(((?:[^()]|\([^()]*\))*)\)'
+      % re.escape(base_classname),
+      line)
+
+  if explicit_constructor_match:
+    is_marked_explicit = explicit_constructor_match.group(1)
+
+    if not explicit_constructor_match.group(2):
+      constructor_args = []
+    else:
+      constructor_args = explicit_constructor_match.group(2).split(',')
+
+    # collapse arguments so that commas in template parameter lists and function
+    # argument parameter lists don't split arguments in two
+    i = 0
+    while i < len(constructor_args):
+      constructor_arg = constructor_args[i]
+      while (constructor_arg.count('<') > constructor_arg.count('>') or
+             constructor_arg.count('(') > constructor_arg.count(')')):
+        constructor_arg += ',' + constructor_args[i + 1]
+        del constructor_args[i + 1]
+      constructor_args[i] = constructor_arg
+      i += 1
+
+    defaulted_args = [arg for arg in constructor_args if '=' in arg]
+    noarg_constructor = (not constructor_args or  # empty arg list
+                         # 'void' arg specifier
+                         (len(constructor_args) == 1 and
+                          constructor_args[0].strip() == 'void'))
+    onearg_constructor = ((len(constructor_args) == 1 and  # exactly one arg
+                           not noarg_constructor) or
+                          # all but at most one arg defaulted
+                          (len(constructor_args) >= 1 and
+                           not noarg_constructor and
+                           len(defaulted_args) >= len(constructor_args) - 1))
+    initializer_list_constructor = bool(
+        onearg_constructor and
+        Search(r'\bstd\s*::\s*initializer_list\b', constructor_args[0]))
+    copy_constructor = bool(
+        onearg_constructor and
+        Match(r'(const\s+)?%s(\s*<[^>]*>)?(\s+const)?\s*(?:<\w+>\s*)?&'
+              % re.escape(base_classname), constructor_args[0].strip()))
+
+    if (not is_marked_explicit and
+        onearg_constructor and
+        not initializer_list_constructor and
+        not copy_constructor):
+      if defaulted_args:
+        error(filename, linenum, 'runtime/explicit', 5,
+              'Constructors callable with one argument '
+              'should be marked explicit.')
+      else:
+        error(filename, linenum, 'runtime/explicit', 5,
+              'Single-parameter constructors should be marked explicit.')
+    elif is_marked_explicit and not onearg_constructor:
+      if noarg_constructor:
+        error(filename, linenum, 'runtime/explicit', 5,
+              'Zero-parameter constructors should not be marked explicit.')
+      else:
+        error(filename, linenum, 'runtime/explicit', 0,
+              'Constructors that require multiple arguments '
+              'should not be marked explicit.')
+
+
+def CheckSpacingForFunctionCall(filename, clean_lines, linenum, error):
+  """Checks for the correctness of various spacing around function calls.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    error: The function to call with any errors found.
+  """
+  line = clean_lines.elided[linenum]
+
+  # Since function calls often occur inside if/for/while/switch
+  # expressions - which have their own, more liberal conventions - we
+  # first see if we should be looking inside such an expression for a
+  # function call, to which we can apply more strict standards.
+  fncall = line    # if there's no control flow construct, look at whole line
+  for pattern in (r'\bif\s*\((.*)\)\s*{',
+                  r'\bfor\s*\((.*)\)\s*{',
+                  r'\bwhile\s*\((.*)\)\s*[{;]',
+                  r'\bswitch\s*\((.*)\)\s*{'):
+    match = Search(pattern, line)
+    if match:
+      fncall = match.group(1)    # look inside the parens for function calls
+      break
+
+  # Except in if/for/while/switch, there should never be space
+  # immediately inside parens (eg "f( 3, 4 )").  We make an exception
+  # for nested parens ( (a+b) + c ).  Likewise, there should never be
+  # a space before a ( when it's a function argument.  I assume it's a
+  # function argument when the char before the whitespace is legal in
+  # a function name (alnum + _) and we're not starting a macro. Also ignore
+  # pointers and references to arrays and functions coz they're too tricky:
+  # we use a very simple way to recognize these:
+  # " (something)(maybe-something)" or
+  # " (something)(maybe-something," or
+  # " (something)[something]"
+  # Note that we assume the contents of [] to be short enough that
+  # they'll never need to wrap.
+  if (  # Ignore control structures.
+      not Search(r'\b(if|for|while|switch|return|new|delete|catch|sizeof)\b',
+                 fncall) and
+      # Ignore pointers/references to functions.
+      not Search(r' \([^)]+\)\([^)]*(\)|,$)', fncall) and
+      # Ignore pointers/references to arrays.
+      not Search(r' \([^)]+\)\[[^\]]+\]', fncall)):
+    if Search(r'\w\s*\(\s(?!\s*\\$)', fncall):      # a ( used for a fn call
+      error(filename, linenum, 'whitespace/parens', 4,
+            'Extra space after ( in function call')
+    elif Search(r'\(\s+(?!(\s*\\)|\()', fncall):
+      error(filename, linenum, 'whitespace/parens', 2,
+            'Extra space after (')
+    if (Search(r'\w\s+\(', fncall) and
+        not Search(r'#\s*define|typedef|using\s+\w+\s*=', fncall) and
+        not Search(r'\w\s+\((\w+::)*\*\w+\)\(', fncall) and
+        not Search(r'\bcase\s+\(', fncall)):
+      # TODO(unknown): Space after an operator function seem to be a common
+      # error, silence those for now by restricting them to highest verbosity.
+      if Search(r'\boperator_*\b', line):
+        error(filename, linenum, 'whitespace/parens', 0,
+              'Extra space before ( in function call')
+      else:
+        error(filename, linenum, 'whitespace/parens', 4,
+              'Extra space before ( in function call')
+    # If the ) is followed only by a newline or a { + newline, assume it's
+    # part of a control statement (if/while/etc), and don't complain
+    if Search(r'[^)]\s+\)\s*[^{\s]', fncall):
+      # If the closing parenthesis is preceded by only whitespaces,
+      # try to give a more descriptive error message.
+      if Search(r'^\s+\)', fncall):
+        error(filename, linenum, 'whitespace/parens', 2,
+              'Closing ) should be moved to the previous line')
+      else:
+        error(filename, linenum, 'whitespace/parens', 2,
+              'Extra space before )')
+
+
+def IsBlankLine(line):
+  """Returns true if the given line is blank.
+
+  We consider a line to be blank if the line is empty or consists of
+  only white spaces.
+
+  Args:
+    line: A line of a string.
+
+  Returns:
+    True, if the given line is blank.
+  """
+  return not line or line.isspace()
+
+
+def CheckForNamespaceIndentation(filename, nesting_state, clean_lines, line,
+                                 error):
+  is_namespace_indent_item = (
+      len(nesting_state.stack) > 1 and
+      nesting_state.stack[-1].check_namespace_indentation and
+      isinstance(nesting_state.previous_stack_top, _NamespaceInfo) and
+      nesting_state.previous_stack_top == nesting_state.stack[-2])
+
+  if ShouldCheckNamespaceIndentation(nesting_state, is_namespace_indent_item,
+                                     clean_lines.elided, line):
+    CheckItemIndentationInNamespace(filename, clean_lines.elided,
+                                    line, error)
+
+
+def CheckForFunctionLengths(filename, clean_lines, linenum,
+                            function_state, error):
+  """Reports for long function bodies.
+
+  For an overview why this is done, see:
+  http://google-styleguide.googlecode.com/svn/trunk/cppguide.xml#Write_Short_Functions
+
+  Uses a simplistic algorithm assuming other style guidelines
+  (especially spacing) are followed.
+  Only checks unindented functions, so class members are unchecked.
+  Trivial bodies are unchecked, so constructors with huge initializer lists
+  may be missed.
+  Blank/comment lines are not counted so as to avoid encouraging the removal
+  of vertical space and comments just to get through a lint check.
+  NOLINT *on the last line of a function* disables this check.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    function_state: Current function name and lines in body so far.
+    error: The function to call with any errors found.
+  """
+  lines = clean_lines.lines
+  line = lines[linenum]
+  joined_line = ''
+
+  starting_func = False
+  regexp = r'(\w(\w|::|\*|\&|\s)*)\('  # decls * & space::name( ...
+  match_result = Match(regexp, line)
+  if match_result:
+    # If the name is all caps and underscores, figure it's a macro and
+    # ignore it, unless it's TEST or TEST_F.
+    function_name = match_result.group(1).split()[-1]
+    if function_name == 'TEST' or function_name == 'TEST_F' or (
+        not Match(r'[A-Z_]+$', function_name)):
+      starting_func = True
+
+  if starting_func:
+    body_found = False
+    for start_linenum in xrange(linenum, clean_lines.NumLines()):
+      start_line = lines[start_linenum]
+      joined_line += ' ' + start_line.lstrip()
+      if Search(r'(;|})', start_line):  # Declarations and trivial functions
+        body_found = True
+        break                              # ... ignore
+      elif Search(r'{', start_line):
+        body_found = True
+        function = Search(r'((\w|:)*)\(', line).group(1)
+        if Match(r'TEST', function):    # Handle TEST... macros
+          parameter_regexp = Search(r'(\(.*\))', joined_line)
+          if parameter_regexp:             # Ignore bad syntax
+            function += parameter_regexp.group(1)
+        else:
+          function += '()'
+        function_state.Begin(function)
+        break
+    if not body_found:
+      # No body for the function (or evidence of a non-function) was found.
+      error(filename, linenum, 'readability/fn_size', 5,
+            'Lint failed to find start of function body.')
+  elif Match(r'^\}\s*$', line):  # function end
+    function_state.Check(error, filename, linenum)
+    function_state.End()
+  elif not Match(r'^\s*$', line):
+    function_state.Count()  # Count non-blank/non-comment lines.
+
+
+_RE_PATTERN_TODO = re.compile(r'^//(\s*)TODO(\(.+?\))?:?(\s|$)?')
+
+
+def CheckComment(line, filename, linenum, next_line_start, error):
+  """Checks for common mistakes in comments.
+
+  Args:
+    line: The line in question.
+    filename: The name of the current file.
+    linenum: The number of the line to check.
+    next_line_start: The first non-whitespace column of the next line.
+    error: The function to call with any errors found.
+  """
+  commentpos = line.find('//')
+  if commentpos != -1:
+    # Check if the // may be in quotes.  If so, ignore it
+    # Comparisons made explicit for clarity -- pylint: disable=g-explicit-bool-comparison
+    if (line.count('"', 0, commentpos) -
+        line.count('\\"', 0, commentpos)) % 2 == 0:   # not in quotes
+      # Allow one space for new scopes, two spaces otherwise:
+      if (not (Match(r'^.*{ *//', line) and next_line_start == commentpos) and
+          ((commentpos >= 1 and
+            line[commentpos-1] not in string.whitespace) or
+           (commentpos >= 2 and
+            line[commentpos-2] not in string.whitespace))):
+        error(filename, linenum, 'whitespace/comments', 2,
+              'At least two spaces is best between code and comments')
+
+      # Checks for common mistakes in TODO comments.
+      comment = line[commentpos:]
+      match = _RE_PATTERN_TODO.match(comment)
+      if match:
+        # One whitespace is correct; zero whitespace is handled elsewhere.
+        leading_whitespace = match.group(1)
+        if len(leading_whitespace) > 1:
+          error(filename, linenum, 'whitespace/todo', 2,
+                'Too many spaces before TODO')
+
+        username = match.group(2)
+        if not username:
+          error(filename, linenum, 'readability/todo', 2,
+                'Missing username in TODO; it should look like '
+                '"// TODO(my_username): Stuff."')
+
+        middle_whitespace = match.group(3)
+        # Comparisons made explicit for correctness -- pylint: disable=g-explicit-bool-comparison
+        if middle_whitespace != ' ' and middle_whitespace != '':
+          error(filename, linenum, 'whitespace/todo', 2,
+                'TODO(my_username) should be followed by a space')
+
+      # If the comment contains an alphanumeric character, there
+      # should be a space somewhere between it and the // unless
+      # it's a /// or //! Doxygen comment.
+      if (Match(r'//[^ ]*\w', comment) and
+          not Match(r'(///|//\!)(\s+|$)', comment)):
+        error(filename, linenum, 'whitespace/comments', 4,
+              'Should have a space between // and comment')
+
+
+def CheckAccess(filename, clean_lines, linenum, nesting_state, error):
+  """Checks for improper use of DISALLOW* macros.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    nesting_state: A NestingState instance which maintains information about
+                   the current stack of nested blocks being parsed.
+    error: The function to call with any errors found.
+  """
+  line = clean_lines.elided[linenum]  # get rid of comments and strings
+
+  matched = Match((r'\s*(DISALLOW_COPY_AND_ASSIGN|'
+                   r'DISALLOW_IMPLICIT_CONSTRUCTORS)'), line)
+  if not matched:
+    return
+  if nesting_state.stack and isinstance(nesting_state.stack[-1], _ClassInfo):
+    if nesting_state.stack[-1].access != 'private':
+      error(filename, linenum, 'readability/constructors', 3,
+            '%s must be in the private: section' % matched.group(1))
+
+  else:
+    # Found DISALLOW* macro outside a class declaration, or perhaps it
+    # was used inside a function when it should have been part of the
+    # class declaration.  We could issue a warning here, but it
+    # probably resulted in a compiler error already.
+    pass
+
+
+def CheckSpacing(filename, clean_lines, linenum, nesting_state, error):
+  """Checks for the correctness of various spacing issues in the code.
+
+  Things we check for: spaces around operators, spaces after
+  if/for/while/switch, no spaces around parens in function calls, two
+  spaces between code and comment, don't start a block with a blank
+  line, don't end a function with a blank line, don't add a blank line
+  after public/protected/private, don't have too many blank lines in a row.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    nesting_state: A NestingState instance which maintains information about
+                   the current stack of nested blocks being parsed.
+    error: The function to call with any errors found.
+  """
+
+  # Don't use "elided" lines here, otherwise we can't check commented lines.
+  # Don't want to use "raw" either, because we don't want to check inside C++11
+  # raw strings,
+  raw = clean_lines.lines_without_raw_strings
+  line = raw[linenum]
+
+  # Before nixing comments, check if the line is blank for no good
+  # reason.  This includes the first line after a block is opened, and
+  # blank lines at the end of a function (ie, right before a line like '}'
+  #
+  # Skip all the blank line checks if we are immediately inside a
+  # namespace body.  In other words, don't issue blank line warnings
+  # for this block:
+  #   namespace {
+  #
+  #   }
+  #
+  # A warning about missing end of namespace comments will be issued instead.
+  #
+  # Also skip blank line checks for 'extern "C"' blocks, which are formatted
+  # like namespaces.
+  if (IsBlankLine(line) and
+      not nesting_state.InNamespaceBody() and
+      not nesting_state.InExternC()):
+    elided = clean_lines.elided
+    prev_line = elided[linenum - 1]
+    prevbrace = prev_line.rfind('{')
+    # TODO(unknown): Don't complain if line before blank line, and line after,
+    #                both start with alnums and are indented the same amount.
+    #                This ignores whitespace at the start of a namespace block
+    #                because those are not usually indented.
+    if prevbrace != -1 and prev_line[prevbrace:].find('}') == -1:
+      # OK, we have a blank line at the start of a code block.  Before we
+      # complain, we check if it is an exception to the rule: The previous
+      # non-empty line has the parameters of a function header that are indented
+      # 4 spaces (because they did not fit in a 80 column line when placed on
+      # the same line as the function name).  We also check for the case where
+      # the previous line is indented 6 spaces, which may happen when the
+      # initializers of a constructor do not fit into a 80 column line.
+      exception = False
+      if Match(r' {6}\w', prev_line):  # Initializer list?
+        # We are looking for the opening column of initializer list, which
+        # should be indented 4 spaces to cause 6 space indentation afterwards.
+        search_position = linenum-2
+        while (search_position >= 0
+               and Match(r' {6}\w', elided[search_position])):
+          search_position -= 1
+        exception = (search_position >= 0
+                     and elided[search_position][:5] == '    :')
+      else:
+        # Search for the function arguments or an initializer list.  We use a
+        # simple heuristic here: If the line is indented 4 spaces; and we have a
+        # closing paren, without the opening paren, followed by an opening brace
+        # or colon (for initializer lists) we assume that it is the last line of
+        # a function header.  If we have a colon indented 4 spaces, it is an
+        # initializer list.
+        exception = (Match(r' {4}\w[^\(]*\)\s*(const\s*)?(\{\s*$|:)',
+                           prev_line)
+                     or Match(r' {4}:', prev_line))
+
+      if not exception:
+        error(filename, linenum, 'whitespace/blank_line', 2,
+              'Redundant blank line at the start of a code block '
+              'should be deleted.')
+    # Ignore blank lines at the end of a block in a long if-else
+    # chain, like this:
+    #   if (condition1) {
+    #     // Something followed by a blank line
+    #
+    #   } else if (condition2) {
+    #     // Something else
+    #   }
+    if linenum + 1 < clean_lines.NumLines():
+      next_line = raw[linenum + 1]
+      if (next_line
+          and Match(r'\s*}', next_line)
+          and next_line.find('} else ') == -1):
+        error(filename, linenum, 'whitespace/blank_line', 3,
+              'Redundant blank line at the end of a code block '
+              'should be deleted.')
+
+    matched = Match(r'\s*(public|protected|private):', prev_line)
+    if matched:
+      error(filename, linenum, 'whitespace/blank_line', 3,
+            'Do not leave a blank line after "%s:"' % matched.group(1))
+
+  # Next, check comments
+  next_line_start = 0
+  if linenum + 1 < clean_lines.NumLines():
+    next_line = raw[linenum + 1]
+    next_line_start = len(next_line) - len(next_line.lstrip())
+  CheckComment(line, filename, linenum, next_line_start, error)
+
+  # get rid of comments and strings
+  line = clean_lines.elided[linenum]
+
+  # You shouldn't have spaces before your brackets, except maybe after
+  # 'delete []' or 'return []() {};'
+  if Search(r'\w\s+\[', line) and not Search(r'(?:delete|return)\s+\[', line):
+    error(filename, linenum, 'whitespace/braces', 5,
+          'Extra space before [')
+
+  # In range-based for, we wanted spaces before and after the colon, but
+  # not around "::" tokens that might appear.
+  if (Search(r'for *\(.*[^:]:[^: ]', line) or
+      Search(r'for *\(.*[^: ]:[^:]', line)):
+    error(filename, linenum, 'whitespace/forcolon', 2,
+          'Missing space around colon in range-based for loop')
+
+
+def CheckOperatorSpacing(filename, clean_lines, linenum, error):
+  """Checks for horizontal spacing around operators.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    error: The function to call with any errors found.
+  """
+  line = clean_lines.elided[linenum]
+
+  # Don't try to do spacing checks for operator methods.  Do this by
+  # replacing the troublesome characters with something else,
+  # preserving column position for all other characters.
+  #
+  # The replacement is done repeatedly to avoid false positives from
+  # operators that call operators.
+  while True:
+    match = Match(r'^(.*\boperator\b)(\S+)(\s*\(.*)$', line)
+    if match:
+      line = match.group(1) + ('_' * len(match.group(2))) + match.group(3)
+    else:
+      break
+
+  # We allow no-spaces around = within an if: "if ( (a=Foo()) == 0 )".
+  # Otherwise not.  Note we only check for non-spaces on *both* sides;
+  # sometimes people put non-spaces on one side when aligning ='s among
+  # many lines (not that this is behavior that I approve of...)
+  if ((Search(r'[\w.]=', line) or
+       Search(r'=[\w.]', line))
+      and not Search(r'\b(if|while|for) ', line)
+      # Operators taken from [lex.operators] in C++11 standard.
+      and not Search(r'(>=|<=|==|!=|&=|\^=|\|=|\+=|\*=|\/=|\%=)', line)
+      and not Search(r'operator=', line)):
+    error(filename, linenum, 'whitespace/operators', 4,
+          'Missing spaces around =')
+
+  # It's ok not to have spaces around binary operators like + - * /, but if
+  # there's too little whitespace, we get concerned.  It's hard to tell,
+  # though, so we punt on this one for now.  TODO.
+
+  # You should always have whitespace around binary operators.
+  #
+  # Check <= and >= first to avoid false positives with < and >, then
+  # check non-include lines for spacing around < and >.
+  #
+  # If the operator is followed by a comma, assume it's be used in a
+  # macro context and don't do any checks.  This avoids false
+  # positives.
+  #
+  # Note that && is not included here.  Those are checked separately
+  # in CheckRValueReference
+  match = Search(r'[^<>=!\s](==|!=|<=|>=|\|\|)[^<>=!\s,;\)]', line)
+  if match:
+    error(filename, linenum, 'whitespace/operators', 3,
+          'Missing spaces around %s' % match.group(1))
+  elif not Match(r'#.*include', line):
+    # Look for < that is not surrounded by spaces.  This is only
+    # triggered if both sides are missing spaces, even though
+    # technically should should flag if at least one side is missing a
+    # space.  This is done to avoid some false positives with shifts.
+    match = Match(r'^(.*[^\s<])<[^\s=<,]', line)
+    if match:
+      (_, _, end_pos) = CloseExpression(
+          clean_lines, linenum, len(match.group(1)))
+      if end_pos <= -1:
+        error(filename, linenum, 'whitespace/operators', 3,
+              'Missing spaces around <')
+
+    # Look for > that is not surrounded by spaces.  Similar to the
+    # above, we only trigger if both sides are missing spaces to avoid
+    # false positives with shifts.
+    match = Match(r'^(.*[^-\s>])>[^\s=>,]', line)
+    if match:
+      (_, _, start_pos) = ReverseCloseExpression(
+          clean_lines, linenum, len(match.group(1)))
+      if start_pos <= -1:
+        error(filename, linenum, 'whitespace/operators', 3,
+              'Missing spaces around >')
+
+  # We allow no-spaces around << when used like this: 10<<20, but
+  # not otherwise (particularly, not when used as streams)
+  #
+  # We also allow operators following an opening parenthesis, since
+  # those tend to be macros that deal with operators.
+  match = Search(r'(operator|[^\s(<])(?:L|UL|ULL|l|ul|ull)?<<([^\s,=<])', line)
+  if (match and not (match.group(1).isdigit() and match.group(2).isdigit()) and
+      not (match.group(1) == 'operator' and match.group(2) == ';')):
+    error(filename, linenum, 'whitespace/operators', 3,
+          'Missing spaces around <<')
+
+  # We allow no-spaces around >> for almost anything.  This is because
+  # C++11 allows ">>" to close nested templates, which accounts for
+  # most cases when ">>" is not followed by a space.
+  #
+  # We still warn on ">>" followed by alpha character, because that is
+  # likely due to ">>" being used for right shifts, e.g.:
+  #   value >> alpha
+  #
+  # When ">>" is used to close templates, the alphanumeric letter that
+  # follows would be part of an identifier, and there should still be
+  # a space separating the template type and the identifier.
+  #   type<type<type>> alpha
+  match = Search(r'>>[a-zA-Z_]', line)
+  if match:
+    error(filename, linenum, 'whitespace/operators', 3,
+          'Missing spaces around >>')
+
+  # There shouldn't be space around unary operators
+  match = Search(r'(!\s|~\s|[\s]--[\s;]|[\s]\+\+[\s;])', line)
+  if match:
+    error(filename, linenum, 'whitespace/operators', 4,
+          'Extra space for operator %s' % match.group(1))
+
+
+def CheckParenthesisSpacing(filename, clean_lines, linenum, error):
+  """Checks for horizontal spacing around parentheses.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    error: The function to call with any errors found.
+  """
+  line = clean_lines.elided[linenum]
+
+  # No spaces after an if, while, switch, or for
+  match = Search(r' (if\(|for\(|while\(|switch\()', line)
+  if match:
+    error(filename, linenum, 'whitespace/parens', 5,
+          'Missing space before ( in %s' % match.group(1))
+
+  # For if/for/while/switch, the left and right parens should be
+  # consistent about how many spaces are inside the parens, and
+  # there should either be zero or one spaces inside the parens.
+  # We don't want: "if ( foo)" or "if ( foo   )".
+  # Exception: "for ( ; foo; bar)" and "for (foo; bar; )" are allowed.
+  match = Search(r'\b(if|for|while|switch)\s*'
+                 r'\(([ ]*)(.).*[^ ]+([ ]*)\)\s*{\s*$',
+                 line)
+  if match:
+    if len(match.group(2)) != len(match.group(4)):
+      if not (match.group(3) == ';' and
+              len(match.group(2)) == 1 + len(match.group(4)) or
+              not match.group(2) and Search(r'\bfor\s*\(.*; \)', line)):
+        error(filename, linenum, 'whitespace/parens', 5,
+              'Mismatching spaces inside () in %s' % match.group(1))
+    if len(match.group(2)) not in [0, 1]:
+      error(filename, linenum, 'whitespace/parens', 5,
+            'Should have zero or one spaces inside ( and ) in %s' %
+            match.group(1))
+
+
+def CheckCommaSpacing(filename, clean_lines, linenum, error):
+  """Checks for horizontal spacing near commas and semicolons.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    error: The function to call with any errors found.
+  """
+  raw = clean_lines.lines_without_raw_strings
+  line = clean_lines.elided[linenum]
+
+  # You should always have a space after a comma (either as fn arg or operator)
+  #
+  # This does not apply when the non-space character following the
+  # comma is another comma, since the only time when that happens is
+  # for empty macro arguments.
+  #
+  # We run this check in two passes: first pass on elided lines to
+  # verify that lines contain missing whitespaces, second pass on raw
+  # lines to confirm that those missing whitespaces are not due to
+  # elided comments.
+  if (Search(r',[^,\s]', ReplaceAll(r'\boperator\s*,\s*\(', 'F(', line)) and
+      Search(r',[^,\s]', raw[linenum])):
+    error(filename, linenum, 'whitespace/comma', 3,
+          'Missing space after ,')
+
+  # You should always have a space after a semicolon
+  # except for few corner cases
+  # TODO(unknown): clarify if 'if (1) { return 1;}' is requires one more
+  # space after ;
+  if Search(r';[^\s};\\)/]', line):
+    error(filename, linenum, 'whitespace/semicolon', 3,
+          'Missing space after ;')
+
+
+def CheckBracesSpacing(filename, clean_lines, linenum, error):
+  """Checks for horizontal spacing near commas.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    error: The function to call with any errors found.
+  """
+  line = clean_lines.elided[linenum]
+
+  # Except after an opening paren, or after another opening brace (in case of
+  # an initializer list, for instance), you should have spaces before your
+  # braces. And since you should never have braces at the beginning of a line,
+  # this is an easy test.
+  match = Match(r'^(.*[^ ({>]){', line)
+  if match:
+    # Try a bit harder to check for brace initialization.  This
+    # happens in one of the following forms:
+    #   Constructor() : initializer_list_{} { ... }
+    #   Constructor{}.MemberFunction()
+    #   Type variable{};
+    #   FunctionCall(type{}, ...);
+    #   LastArgument(..., type{});
+    #   LOG(INFO) << type{} << " ...";
+    #   map_of_type[{...}] = ...;
+    #   ternary = expr ? new type{} : nullptr;
+    #   OuterTemplate<InnerTemplateConstructor<Type>{}>
+    #
+    # We check for the character following the closing brace, and
+    # silence the warning if it's one of those listed above, i.e.
+    # "{.;,)<>]:".
+    #
+    # To account for nested initializer list, we allow any number of
+    # closing braces up to "{;,)<".  We can't simply silence the
+    # warning on first sight of closing brace, because that would
+    # cause false negatives for things that are not initializer lists.
+    #   Silence this:         But not this:
+    #     Outer{                if (...) {
+    #       Inner{...}            if (...){  // Missing space before {
+    #     };                    }
+    #
+    # There is a false negative with this approach if people inserted
+    # spurious semicolons, e.g. "if (cond){};", but we will catch the
+    # spurious semicolon with a separate check.
+    (endline, endlinenum, endpos) = CloseExpression(
+        clean_lines, linenum, len(match.group(1)))
+    trailing_text = ''
+    if endpos > -1:
+      trailing_text = endline[endpos:]
+    for offset in xrange(endlinenum + 1,
+                         min(endlinenum + 3, clean_lines.NumLines() - 1)):
+      trailing_text += clean_lines.elided[offset]
+    if not Match(r'^[\s}]*[{.;,)<>\]:]', trailing_text):
+      error(filename, linenum, 'whitespace/braces', 5,
+            'Missing space before {')
+
+  # Make sure '} else {' has spaces.
+  if Search(r'}else', line):
+    error(filename, linenum, 'whitespace/braces', 5,
+          'Missing space before else')
+
+  # You shouldn't have a space before a semicolon at the end of the line.
+  # There's a special case for "for" since the style guide allows space before
+  # the semicolon there.
+  if Search(r':\s*;\s*$', line):
+    error(filename, linenum, 'whitespace/semicolon', 5,
+          'Semicolon defining empty statement. Use {} instead.')
+  elif Search(r'^\s*;\s*$', line):
+    error(filename, linenum, 'whitespace/semicolon', 5,
+          'Line contains only semicolon. If this should be an empty statement, '
+          'use {} instead.')
+  elif (Search(r'\s+;\s*$', line) and
+        not Search(r'\bfor\b', line)):
+    error(filename, linenum, 'whitespace/semicolon', 5,
+          'Extra space before last semicolon. If this should be an empty '
+          'statement, use {} instead.')
+
+
+def IsDecltype(clean_lines, linenum, column):
+  """Check if the token ending on (linenum, column) is decltype().
+
+  Args:
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: the number of the line to check.
+    column: end column of the token to check.
+  Returns:
+    True if this token is decltype() expression, False otherwise.
+  """
+  (text, _, start_col) = ReverseCloseExpression(clean_lines, linenum, column)
+  if start_col < 0:
+    return False
+  if Search(r'\bdecltype\s*$', text[0:start_col]):
+    return True
+  return False
+
+
+def IsTemplateParameterList(clean_lines, linenum, column):
+  """Check if the token ending on (linenum, column) is the end of template<>.
+
+  Args:
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: the number of the line to check.
+    column: end column of the token to check.
+  Returns:
+    True if this token is end of a template parameter list, False otherwise.
+  """
+  (_, startline, startpos) = ReverseCloseExpression(
+      clean_lines, linenum, column)
+  if (startpos > -1 and
+      Search(r'\btemplate\s*$', clean_lines.elided[startline][0:startpos])):
+    return True
+  return False
+
+
+def IsRValueType(typenames, clean_lines, nesting_state, linenum, column):
+  """Check if the token ending on (linenum, column) is a type.
+
+  Assumes that text to the right of the column is "&&" or a function
+  name.
+
+  Args:
+    typenames: set of type names from template-argument-list.
+    clean_lines: A CleansedLines instance containing the file.
+    nesting_state: A NestingState instance which maintains information about
+                   the current stack of nested blocks being parsed.
+    linenum: the number of the line to check.
+    column: end column of the token to check.
+  Returns:
+    True if this token is a type, False if we are not sure.
+  """
+  prefix = clean_lines.elided[linenum][0:column]
+
+  # Get one word to the left.  If we failed to do so, this is most
+  # likely not a type, since it's unlikely that the type name and "&&"
+  # would be split across multiple lines.
+  match = Match(r'^(.*)(\b\w+|[>*)&])\s*$', prefix)
+  if not match:
+    return False
+
+  # Check text following the token.  If it's "&&>" or "&&," or "&&...", it's
+  # most likely a rvalue reference used inside a template.
+  suffix = clean_lines.elided[linenum][column:]
+  if Match(r'&&\s*(?:[>,]|\.\.\.)', suffix):
+    return True
+
+  # Check for known types and end of templates:
+  #   int&& variable
+  #   vector<int>&& variable
+  #
+  # Because this function is called recursively, we also need to
+  # recognize pointer and reference types:
+  #   int* Function()
+  #   int& Function()
+  if (match.group(2) in typenames or
+      match.group(2) in ['char', 'char16_t', 'char32_t', 'wchar_t', 'bool',
+                         'short', 'int', 'long', 'signed', 'unsigned',
+                         'float', 'double', 'void', 'auto', '>', '*', '&']):
+    return True
+
+  # If we see a close parenthesis, look for decltype on the other side.
+  # decltype would unambiguously identify a type, anything else is
+  # probably a parenthesized expression and not a type.
+  if match.group(2) == ')':
+    return IsDecltype(
+        clean_lines, linenum, len(match.group(1)) + len(match.group(2)) - 1)
+
+  # Check for casts and cv-qualifiers.
+  #   match.group(1)  remainder
+  #   --------------  ---------
+  #   const_cast<     type&&
+  #   const           type&&
+  #   type            const&&
+  if Search(r'\b(?:const_cast\s*<|static_cast\s*<|dynamic_cast\s*<|'
+            r'reinterpret_cast\s*<|\w+\s)\s*$',
+            match.group(1)):
+    return True
+
+  # Look for a preceding symbol that might help differentiate the context.
+  # These are the cases that would be ambiguous:
+  #   match.group(1)  remainder
+  #   --------------  ---------
+  #   Call         (   expression &&
+  #   Declaration  (   type&&
+  #   sizeof       (   type&&
+  #   if           (   expression &&
+  #   while        (   expression &&
+  #   for          (   type&&
+  #   for(         ;   expression &&
+  #   statement    ;   type&&
+  #   block        {   type&&
+  #   constructor  {   expression &&
+  start = linenum
+  line = match.group(1)
+  match_symbol = None
+  while start >= 0:
+    # We want to skip over identifiers and commas to get to a symbol.
+    # Commas are skipped so that we can find the opening parenthesis
+    # for function parameter lists.
+    match_symbol = Match(r'^(.*)([^\w\s,])[\w\s,]*$', line)
+    if match_symbol:
+      break
+    start -= 1
+    line = clean_lines.elided[start]
+
+  if not match_symbol:
+    # Probably the first statement in the file is an rvalue reference
+    return True
+
+  if match_symbol.group(2) == '}':
+    # Found closing brace, probably an indicate of this:
+    #   block{} type&&
+    return True
+
+  if match_symbol.group(2) == ';':
+    # Found semicolon, probably one of these:
+    #   for(; expression &&
+    #   statement; type&&
+
+    # Look for the previous 'for(' in the previous lines.
+    before_text = match_symbol.group(1)
+    for i in xrange(start - 1, max(start - 6, 0), -1):
+      before_text = clean_lines.elided[i] + before_text
+    if Search(r'for\s*\([^{};]*$', before_text):
+      # This is the condition inside a for-loop
+      return False
+
+    # Did not find a for-init-statement before this semicolon, so this
+    # is probably a new statement and not a condition.
+    return True
+
+  if match_symbol.group(2) == '{':
+    # Found opening brace, probably one of these:
+    #   block{ type&& = ... ; }
+    #   constructor{ expression && expression }
+
+    # Look for a closing brace or a semicolon.  If we see a semicolon
+    # first, this is probably a rvalue reference.
+    line = clean_lines.elided[start][0:len(match_symbol.group(1)) + 1]
+    end = start
+    depth = 1
+    while True:
+      for ch in line:
+        if ch == ';':
+          return True
+        elif ch == '{':
+          depth += 1
+        elif ch == '}':
+          depth -= 1
+          if depth == 0:
+            return False
+      end += 1
+      if end >= clean_lines.NumLines():
+        break
+      line = clean_lines.elided[end]
+    # Incomplete program?
+    return False
+
+  if match_symbol.group(2) == '(':
+    # Opening parenthesis.  Need to check what's to the left of the
+    # parenthesis.  Look back one extra line for additional context.
+    before_text = match_symbol.group(1)
+    if linenum > 1:
+      before_text = clean_lines.elided[linenum - 1] + before_text
+    before_text = match_symbol.group(1)
+
+    # Patterns that are likely to be types:
+    #   [](type&&
+    #   for (type&&
+    #   sizeof(type&&
+    #   operator=(type&&
+    #
+    if Search(r'(?:\]|\bfor|\bsizeof|\boperator\s*\S+\s*)\s*$', before_text):
+      return True
+
+    # Patterns that are likely to be expressions:
+    #   if (expression &&
+    #   while (expression &&
+    #   : initializer(expression &&
+    #   , initializer(expression &&
+    #   ( FunctionCall(expression &&
+    #   + FunctionCall(expression &&
+    #   + (expression &&
+    #
+    # The last '+' represents operators such as '+' and '-'.
+    if Search(r'(?:\bif|\bwhile|[-+=%^(<!?:,&*]\s*)$', before_text):
+      return False
+
+    # Something else.  Check that tokens to the left look like
+    #   return_type function_name
+    match_func = Match(r'^(.*\S.*)\s+\w(?:\w|::)*(?:<[^<>]*>)?\s*$',
+                       match_symbol.group(1))
+    if match_func:
+      # Check for constructors, which don't have return types.
+      if Search(r'\b(?:explicit|inline)$', match_func.group(1)):
+        return True
+      implicit_constructor = Match(r'\s*(\w+)\((?:const\s+)?(\w+)', prefix)
+      if (implicit_constructor and
+          implicit_constructor.group(1) == implicit_constructor.group(2)):
+        return True
+      return IsRValueType(typenames, clean_lines, nesting_state, linenum,
+                          len(match_func.group(1)))
+
+    # Nothing before the function name.  If this is inside a block scope,
+    # this is probably a function call.
+    return not (nesting_state.previous_stack_top and
+                nesting_state.previous_stack_top.IsBlockInfo())
+
+  if match_symbol.group(2) == '>':
+    # Possibly a closing bracket, check that what's on the other side
+    # looks like the start of a template.
+    return IsTemplateParameterList(
+        clean_lines, start, len(match_symbol.group(1)))
+
+  # Some other symbol, usually something like "a=b&&c".  This is most
+  # likely not a type.
+  return False
+
+
+def IsDeletedOrDefault(clean_lines, linenum):
+  """Check if current constructor or operator is deleted or default.
+
+  Args:
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+  Returns:
+    True if this is a deleted or default constructor.
+  """
+  open_paren = clean_lines.elided[linenum].find('(')
+  if open_paren < 0:
+    return False
+  (close_line, _, close_paren) = CloseExpression(
+      clean_lines, linenum, open_paren)
+  if close_paren < 0:
+    return False
+  return Match(r'\s*=\s*(?:delete|default)\b', close_line[close_paren:])
+
+
+def IsRValueAllowed(clean_lines, linenum, typenames):
+  """Check if RValue reference is allowed on a particular line.
+
+  Args:
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    typenames: set of type names from template-argument-list.
+  Returns:
+    True if line is within the region where RValue references are allowed.
+  """
+  # Allow region marked by PUSH/POP macros
+  for i in xrange(linenum, 0, -1):
+    line = clean_lines.elided[i]
+    if Match(r'GOOGLE_ALLOW_RVALUE_REFERENCES_(?:PUSH|POP)', line):
+      if not line.endswith('PUSH'):
+        return False
+      for j in xrange(linenum, clean_lines.NumLines(), 1):
+        line = clean_lines.elided[j]
+        if Match(r'GOOGLE_ALLOW_RVALUE_REFERENCES_(?:PUSH|POP)', line):
+          return line.endswith('POP')
+
+  # Allow operator=
+  line = clean_lines.elided[linenum]
+  if Search(r'\boperator\s*=\s*\(', line):
+    return IsDeletedOrDefault(clean_lines, linenum)
+
+  # Allow constructors
+  match = Match(r'\s*(?:[\w<>]+::)*([\w<>]+)\s*::\s*([\w<>]+)\s*\(', line)
+  if match and match.group(1) == match.group(2):
+    return IsDeletedOrDefault(clean_lines, linenum)
+  if Search(r'\b(?:explicit|inline)\s+[\w<>]+\s*\(', line):
+    return IsDeletedOrDefault(clean_lines, linenum)
+
+  if Match(r'\s*[\w<>]+\s*\(', line):
+    previous_line = 'ReturnType'
+    if linenum > 0:
+      previous_line = clean_lines.elided[linenum - 1]
+    if Match(r'^\s*$', previous_line) or Search(r'[{}:;]\s*$', previous_line):
+      return IsDeletedOrDefault(clean_lines, linenum)
+
+  # Reject types not mentioned in template-argument-list
+  while line:
+    match = Match(r'^.*?(\w+)\s*&&(.*)$', line)
+    if not match:
+      break
+    if match.group(1) not in typenames:
+      return False
+    line = match.group(2)
+
+  # All RValue types that were in template-argument-list should have
+  # been removed by now.  Those were allowed, assuming that they will
+  # be forwarded.
+  #
+  # If there are no remaining RValue types left (i.e. types that were
+  # not found in template-argument-list), flag those as not allowed.
+  return line.find('&&') < 0
+
+
+def GetTemplateArgs(clean_lines, linenum):
+  """Find list of template arguments associated with this function declaration.
+
+  Args:
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: Line number containing the start of the function declaration,
+             usually one line after the end of the template-argument-list.
+  Returns:
+    Set of type names, or empty set if this does not appear to have
+    any template parameters.
+  """
+  # Find start of function
+  func_line = linenum
+  while func_line > 0:
+    line = clean_lines.elided[func_line]
+    if Match(r'^\s*$', line):
+      return set()
+    if line.find('(') >= 0:
+      break
+    func_line -= 1
+  if func_line == 0:
+    return set()
+
+  # Collapse template-argument-list into a single string
+  argument_list = ''
+  match = Match(r'^(\s*template\s*)<', clean_lines.elided[func_line])
+  if match:
+    # template-argument-list on the same line as function name
+    start_col = len(match.group(1))
+    _, end_line, end_col = CloseExpression(clean_lines, func_line, start_col)
+    if end_col > -1 and end_line == func_line:
+      start_col += 1  # Skip the opening bracket
+      argument_list = clean_lines.elided[func_line][start_col:end_col]
+
+  elif func_line > 1:
+    # template-argument-list one line before function name
+    match = Match(r'^(.*)>\s*$', clean_lines.elided[func_line - 1])
+    if match:
+      end_col = len(match.group(1))
+      _, start_line, start_col = ReverseCloseExpression(
+          clean_lines, func_line - 1, end_col)
+      if start_col > -1:
+        start_col += 1  # Skip the opening bracket
+        while start_line < func_line - 1:
+          argument_list += clean_lines.elided[start_line][start_col:]
+          start_col = 0
+          start_line += 1
+        argument_list += clean_lines.elided[func_line - 1][start_col:end_col]
+
+  if not argument_list:
+    return set()
+
+  # Extract type names
+  typenames = set()
+  while True:
+    match = Match(r'^[,\s]*(?:typename|class)(?:\.\.\.)?\s+(\w+)(.*)$',
+                  argument_list)
+    if not match:
+      break
+    typenames.add(match.group(1))
+    argument_list = match.group(2)
+  return typenames
+
+
+def CheckRValueReference(filename, clean_lines, linenum, nesting_state, error):
+  """Check for rvalue references.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    nesting_state: A NestingState instance which maintains information about
+                   the current stack of nested blocks being parsed.
+    error: The function to call with any errors found.
+  """
+  # Find lines missing spaces around &&.
+  # TODO(unknown): currently we don't check for rvalue references
+  # with spaces surrounding the && to avoid false positives with
+  # boolean expressions.
+  line = clean_lines.elided[linenum]
+  match = Match(r'^(.*\S)&&', line)
+  if not match:
+    match = Match(r'(.*)&&\S', line)
+  if (not match) or '(&&)' in line or Search(r'\boperator\s*$', match.group(1)):
+    return
+
+  # Either poorly formed && or an rvalue reference, check the context
+  # to get a more accurate error message.  Mostly we want to determine
+  # if what's to the left of "&&" is a type or not.
+  typenames = GetTemplateArgs(clean_lines, linenum)
+  and_pos = len(match.group(1))
+  if IsRValueType(typenames, clean_lines, nesting_state, linenum, and_pos):
+    if not IsRValueAllowed(clean_lines, linenum, typenames):
+      error(filename, linenum, 'build/c++11', 3,
+            'RValue references are an unapproved C++ feature.')
+  else:
+    error(filename, linenum, 'whitespace/operators', 3,
+          'Missing spaces around &&')
+
+
+def CheckSectionSpacing(filename, clean_lines, class_info, linenum, error):
+  """Checks for additional blank line issues related to sections.
+
+  Currently the only thing checked here is blank line before protected/private.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    class_info: A _ClassInfo objects.
+    linenum: The number of the line to check.
+    error: The function to call with any errors found.
+  """
+  # Skip checks if the class is small, where small means 25 lines or less.
+  # 25 lines seems like a good cutoff since that's the usual height of
+  # terminals, and any class that can't fit in one screen can't really
+  # be considered "small".
+  #
+  # Also skip checks if we are on the first line.  This accounts for
+  # classes that look like
+  #   class Foo { public: ... };
+  #
+  # If we didn't find the end of the class, last_line would be zero,
+  # and the check will be skipped by the first condition.
+  if (class_info.last_line - class_info.starting_linenum <= 24 or
+      linenum <= class_info.starting_linenum):
+    return
+
+  matched = Match(r'\s*(public|protected|private):', clean_lines.lines[linenum])
+  if matched:
+    # Issue warning if the line before public/protected/private was
+    # not a blank line, but don't do this if the previous line contains
+    # "class" or "struct".  This can happen two ways:
+    #  - We are at the beginning of the class.
+    #  - We are forward-declaring an inner class that is semantically
+    #    private, but needed to be public for implementation reasons.
+    # Also ignores cases where the previous line ends with a backslash as can be
+    # common when defining classes in C macros.
+    prev_line = clean_lines.lines[linenum - 1]
+    if (not IsBlankLine(prev_line) and
+        not Search(r'\b(class|struct)\b', prev_line) and
+        not Search(r'\\$', prev_line)):
+      # Try a bit harder to find the beginning of the class.  This is to
+      # account for multi-line base-specifier lists, e.g.:
+      #   class Derived
+      #       : public Base {
+      end_class_head = class_info.starting_linenum
+      for i in range(class_info.starting_linenum, linenum):
+        if Search(r'\{\s*$', clean_lines.lines[i]):
+          end_class_head = i
+          break
+      if end_class_head < linenum - 1:
+        error(filename, linenum, 'whitespace/blank_line', 3,
+              '"%s:" should be preceded by a blank line' % matched.group(1))
+
+
+def GetPreviousNonBlankLine(clean_lines, linenum):
+  """Return the most recent non-blank line and its line number.
+
+  Args:
+    clean_lines: A CleansedLines instance containing the file contents.
+    linenum: The number of the line to check.
+
+  Returns:
+    A tuple with two elements.  The first element is the contents of the last
+    non-blank line before the current line, or the empty string if this is the
+    first non-blank line.  The second is the line number of that line, or -1
+    if this is the first non-blank line.
+  """
+
+  prevlinenum = linenum - 1
+  while prevlinenum >= 0:
+    prevline = clean_lines.elided[prevlinenum]
+    if not IsBlankLine(prevline):     # if not a blank line...
+      return (prevline, prevlinenum)
+    prevlinenum -= 1
+  return ('', -1)
+
+
+def CheckBraces(filename, clean_lines, linenum, error):
+  """Looks for misplaced braces (e.g. at the end of line).
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    error: The function to call with any errors found.
+  """
+
+  line = clean_lines.elided[linenum]        # get rid of comments and strings
+
+  if Match(r'\s*{\s*$', line):
+    # We allow an open brace to start a line in the case where someone is using
+    # braces in a block to explicitly create a new scope, which is commonly used
+    # to control the lifetime of stack-allocated variables.  Braces are also
+    # used for brace initializers inside function calls.  We don't detect this
+    # perfectly: we just don't complain if the last non-whitespace character on
+    # the previous non-blank line is ',', ';', ':', '(', '{', or '}', or if the
+    # previous line starts a preprocessor block.
+    prevline = GetPreviousNonBlankLine(clean_lines, linenum)[0]
+    if (not Search(r'[,;:}{(]\s*$', prevline) and
+        not Match(r'\s*#', prevline)):
+      error(filename, linenum, 'whitespace/braces', 4,
+            '{ should almost always be at the end of the previous line')
+
+  # An else clause should be on the same line as the preceding closing brace.
+  if Match(r'\s*else\b\s*(?:if\b|\{|$)', line):
+    prevline = GetPreviousNonBlankLine(clean_lines, linenum)[0]
+    if Match(r'\s*}\s*$', prevline):
+      error(filename, linenum, 'whitespace/newline', 4,
+            'An else should appear on the same line as the preceding }')
+
+  # If braces come on one side of an else, they should be on both.
+  # However, we have to worry about "else if" that spans multiple lines!
+  if Search(r'else if\s*\(', line):       # could be multi-line if
+    brace_on_left = bool(Search(r'}\s*else if\s*\(', line))
+    # find the ( after the if
+    pos = line.find('else if')
+    pos = line.find('(', pos)
+    if pos > 0:
+      (endline, _, endpos) = CloseExpression(clean_lines, linenum, pos)
+      brace_on_right = endline[endpos:].find('{') != -1
+      if brace_on_left != brace_on_right:    # must be brace after if
+        error(filename, linenum, 'readability/braces', 5,
+              'If an else has a brace on one side, it should have it on both')
+  elif Search(r'}\s*else[^{]*$', line) or Match(r'[^}]*else\s*{', line):
+    error(filename, linenum, 'readability/braces', 5,
+          'If an else has a brace on one side, it should have it on both')
+
+  # Likewise, an else should never have the else clause on the same line
+  if Search(r'\belse [^\s{]', line) and not Search(r'\belse if\b', line):
+    error(filename, linenum, 'whitespace/newline', 4,
+          'Else clause should never be on same line as else (use 2 lines)')
+
+  # In the same way, a do/while should never be on one line
+  if Match(r'\s*do [^\s{]', line):
+    error(filename, linenum, 'whitespace/newline', 4,
+          'do/while clauses should not be on a single line')
+
+  # Check single-line if/else bodies. The style guide says 'curly braces are not
+  # required for single-line statements'. We additionally allow multi-line,
+  # single statements, but we reject anything with more than one semicolon in
+  # it. This means that the first semicolon after the if should be at the end of
+  # its line, and the line after that should have an indent level equal to or
+  # lower than the if. We also check for ambiguous if/else nesting without
+  # braces.
+  if_else_match = Search(r'\b(if\s*\(|else\b)', line)
+  if if_else_match and not Match(r'\s*#', line):
+    if_indent = GetIndentLevel(line)
+    endline, endlinenum, endpos = line, linenum, if_else_match.end()
+    if_match = Search(r'\bif\s*\(', line)
+    if if_match:
+      # This could be a multiline if condition, so find the end first.
+      pos = if_match.end() - 1
+      (endline, endlinenum, endpos) = CloseExpression(clean_lines, linenum, pos)
+    # Check for an opening brace, either directly after the if or on the next
+    # line. If found, this isn't a single-statement conditional.
+    if (not Match(r'\s*{', endline[endpos:])
+        and not (Match(r'\s*$', endline[endpos:])
+                 and endlinenum < (len(clean_lines.elided) - 1)
+                 and Match(r'\s*{', clean_lines.elided[endlinenum + 1]))):
+      while (endlinenum < len(clean_lines.elided)
+             and ';' not in clean_lines.elided[endlinenum][endpos:]):
+        endlinenum += 1
+        endpos = 0
+      if endlinenum < len(clean_lines.elided):
+        endline = clean_lines.elided[endlinenum]
+        # We allow a mix of whitespace and closing braces (e.g. for one-liner
+        # methods) and a single \ after the semicolon (for macros)
+        endpos = endline.find(';')
+        if not Match(r';[\s}]*(\\?)$', endline[endpos:]):
+          # Semicolon isn't the last character, there's something trailing.
+          # Output a warning if the semicolon is not contained inside
+          # a lambda expression.
+          if not Match(r'^[^{};]*\[[^\[\]]*\][^{}]*\{[^{}]*\}\s*\)*[;,]\s*$',
+                       endline):
+            error(filename, linenum, 'readability/braces', 4,
+                  'If/else bodies with multiple statements require braces')
+        elif endlinenum < len(clean_lines.elided) - 1:
+          # Make sure the next line is dedented
+          next_line = clean_lines.elided[endlinenum + 1]
+          next_indent = GetIndentLevel(next_line)
+          # With ambiguous nested if statements, this will error out on the
+          # if that *doesn't* match the else, regardless of whether it's the
+          # inner one or outer one.
+          if (if_match and Match(r'\s*else\b', next_line)
+              and next_indent != if_indent):
+            error(filename, linenum, 'readability/braces', 4,
+                  'Else clause should be indented at the same level as if. '
+                  'Ambiguous nested if/else chains require braces.')
+          elif next_indent > if_indent:
+            error(filename, linenum, 'readability/braces', 4,
+                  'If/else bodies with multiple statements require braces')
+
+
+def CheckTrailingSemicolon(filename, clean_lines, linenum, error):
+  """Looks for redundant trailing semicolon.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    error: The function to call with any errors found.
+  """
+
+  line = clean_lines.elided[linenum]
+
+  # Block bodies should not be followed by a semicolon.  Due to C++11
+  # brace initialization, there are more places where semicolons are
+  # required than not, so we use a whitelist approach to check these
+  # rather than a blacklist.  These are the places where "};" should
+  # be replaced by just "}":
+  # 1. Some flavor of block following closing parenthesis:
+  #    for (;;) {};
+  #    while (...) {};
+  #    switch (...) {};
+  #    Function(...) {};
+  #    if (...) {};
+  #    if (...) else if (...) {};
+  #
+  # 2. else block:
+  #    if (...) else {};
+  #
+  # 3. const member function:
+  #    Function(...) const {};
+  #
+  # 4. Block following some statement:
+  #    x = 42;
+  #    {};
+  #
+  # 5. Block at the beginning of a function:
+  #    Function(...) {
+  #      {};
+  #    }
+  #
+  #    Note that naively checking for the preceding "{" will also match
+  #    braces inside multi-dimensional arrays, but this is fine since
+  #    that expression will not contain semicolons.
+  #
+  # 6. Block following another block:
+  #    while (true) {}
+  #    {};
+  #
+  # 7. End of namespaces:
+  #    namespace {};
+  #
+  #    These semicolons seems far more common than other kinds of
+  #    redundant semicolons, possibly due to people converting classes
+  #    to namespaces.  For now we do not warn for this case.
+  #
+  # Try matching case 1 first.
+  match = Match(r'^(.*\)\s*)\{', line)
+  if match:
+    # Matched closing parenthesis (case 1).  Check the token before the
+    # matching opening parenthesis, and don't warn if it looks like a
+    # macro.  This avoids these false positives:
+    #  - macro that defines a base class
+    #  - multi-line macro that defines a base class
+    #  - macro that defines the whole class-head
+    #
+    # But we still issue warnings for macros that we know are safe to
+    # warn, specifically:
+    #  - TEST, TEST_F, TEST_P, MATCHER, MATCHER_P
+    #  - TYPED_TEST
+    #  - INTERFACE_DEF
+    #  - EXCLUSIVE_LOCKS_REQUIRED, SHARED_LOCKS_REQUIRED, LOCKS_EXCLUDED:
+    #
+    # We implement a whitelist of safe macros instead of a blacklist of
+    # unsafe macros, even though the latter appears less frequently in
+    # google code and would have been easier to implement.  This is because
+    # the downside for getting the whitelist wrong means some extra
+    # semicolons, while the downside for getting the blacklist wrong
+    # would result in compile errors.
+    #
+    # In addition to macros, we also don't want to warn on
+    #  - Compound literals
+    #  - Lambdas
+    #  - alignas specifier with anonymous structs:
+    closing_brace_pos = match.group(1).rfind(')')
+    opening_parenthesis = ReverseCloseExpression(
+        clean_lines, linenum, closing_brace_pos)
+    if opening_parenthesis[2] > -1:
+      line_prefix = opening_parenthesis[0][0:opening_parenthesis[2]]
+      macro = Search(r'\b([A-Z_]+)\s*$', line_prefix)
+      func = Match(r'^(.*\])\s*$', line_prefix)
+      if ((macro and
+           macro.group(1) not in (
+               'TEST', 'TEST_F', 'MATCHER', 'MATCHER_P', 'TYPED_TEST',
+               'EXCLUSIVE_LOCKS_REQUIRED', 'SHARED_LOCKS_REQUIRED',
+               'LOCKS_EXCLUDED', 'INTERFACE_DEF')) or
+          (func and not Search(r'\boperator\s*\[\s*\]', func.group(1))) or
+          Search(r'\b(?:struct|union)\s+alignas\s*$', line_prefix) or
+          Search(r'\s+=\s*$', line_prefix)):
+        match = None
+    if (match and
+        opening_parenthesis[1] > 1 and
+        Search(r'\]\s*$', clean_lines.elided[opening_parenthesis[1] - 1])):
+      # Multi-line lambda-expression
+      match = None
+
+  else:
+    # Try matching cases 2-3.
+    match = Match(r'^(.*(?:else|\)\s*const)\s*)\{', line)
+    if not match:
+      # Try matching cases 4-6.  These are always matched on separate lines.
+      #
+      # Note that we can't simply concatenate the previous line to the
+      # current line and do a single match, otherwise we may output
+      # duplicate warnings for the blank line case:
+      #   if (cond) {
+      #     // blank line
+      #   }
+      prevline = GetPreviousNonBlankLine(clean_lines, linenum)[0]
+      if prevline and Search(r'[;{}]\s*$', prevline):
+        match = Match(r'^(\s*)\{', line)
+
+  # Check matching closing brace
+  if match:
+    (endline, endlinenum, endpos) = CloseExpression(
+        clean_lines, linenum, len(match.group(1)))
+    if endpos > -1 and Match(r'^\s*;', endline[endpos:]):
+      # Current {} pair is eligible for semicolon check, and we have found
+      # the redundant semicolon, output warning here.
+      #
+      # Note: because we are scanning forward for opening braces, and
+      # outputting warnings for the matching closing brace, if there are
+      # nested blocks with trailing semicolons, we will get the error
+      # messages in reversed order.
+      error(filename, endlinenum, 'readability/braces', 4,
+            "You don't need a ; after a }")
+
+
+def CheckEmptyBlockBody(filename, clean_lines, linenum, error):
+  """Look for empty loop/conditional body with only a single semicolon.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    error: The function to call with any errors found.
+  """
+
+  # Search for loop keywords at the beginning of the line.  Because only
+  # whitespaces are allowed before the keywords, this will also ignore most
+  # do-while-loops, since those lines should start with closing brace.
+  #
+  # We also check "if" blocks here, since an empty conditional block
+  # is likely an error.
+  line = clean_lines.elided[linenum]
+  matched = Match(r'\s*(for|while|if)\s*\(', line)
+  if matched:
+    # Find the end of the conditional expression
+    (end_line, end_linenum, end_pos) = CloseExpression(
+        clean_lines, linenum, line.find('('))
+
+    # Output warning if what follows the condition expression is a semicolon.
+    # No warning for all other cases, including whitespace or newline, since we
+    # have a separate check for semicolons preceded by whitespace.
+    if end_pos >= 0 and Match(r';', end_line[end_pos:]):
+      if matched.group(1) == 'if':
+        error(filename, end_linenum, 'whitespace/empty_conditional_body', 5,
+              'Empty conditional bodies should use {}')
+      else:
+        error(filename, end_linenum, 'whitespace/empty_loop_body', 5,
+              'Empty loop bodies should use {} or continue')
+
+
+def FindCheckMacro(line):
+  """Find a replaceable CHECK-like macro.
+
+  Args:
+    line: line to search on.
+  Returns:
+    (macro name, start position), or (None, -1) if no replaceable
+    macro is found.
+  """
+  for macro in _CHECK_MACROS:
+    i = line.find(macro)
+    if i >= 0:
+      # Find opening parenthesis.  Do a regular expression match here
+      # to make sure that we are matching the expected CHECK macro, as
+      # opposed to some other macro that happens to contain the CHECK
+      # substring.
+      matched = Match(r'^(.*\b' + macro + r'\s*)\(', line)
+      if not matched:
+        continue
+      return (macro, len(matched.group(1)))
+  return (None, -1)
+
+
+def CheckCheck(filename, clean_lines, linenum, error):
+  """Checks the use of CHECK and EXPECT macros.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    error: The function to call with any errors found.
+  """
+
+  # Decide the set of replacement macros that should be suggested
+  lines = clean_lines.elided
+  (check_macro, start_pos) = FindCheckMacro(lines[linenum])
+  if not check_macro:
+    return
+
+  # Find end of the boolean expression by matching parentheses
+  (last_line, end_line, end_pos) = CloseExpression(
+      clean_lines, linenum, start_pos)
+  if end_pos < 0:
+    return
+
+  # If the check macro is followed by something other than a
+  # semicolon, assume users will log their own custom error messages
+  # and don't suggest any replacements.
+  if not Match(r'\s*;', last_line[end_pos:]):
+    return
+
+  if linenum == end_line:
+    expression = lines[linenum][start_pos + 1:end_pos - 1]
+  else:
+    expression = lines[linenum][start_pos + 1:]
+    for i in xrange(linenum + 1, end_line):
+      expression += lines[i]
+    expression += last_line[0:end_pos - 1]
+
+  # Parse expression so that we can take parentheses into account.
+  # This avoids false positives for inputs like "CHECK((a < 4) == b)",
+  # which is not replaceable by CHECK_LE.
+  lhs = ''
+  rhs = ''
+  operator = None
+  while expression:
+    matched = Match(r'^\s*(<<|<<=|>>|>>=|->\*|->|&&|\|\||'
+                    r'==|!=|>=|>|<=|<|\()(.*)$', expression)
+    if matched:
+      token = matched.group(1)
+      if token == '(':
+        # Parenthesized operand
+        expression = matched.group(2)
+        (end, _) = FindEndOfExpressionInLine(expression, 0, ['('])
+        if end < 0:
+          return  # Unmatched parenthesis
+        lhs += '(' + expression[0:end]
+        expression = expression[end:]
+      elif token in ('&&', '||'):
+        # Logical and/or operators.  This means the expression
+        # contains more than one term, for example:
+        #   CHECK(42 < a && a < b);
+        #
+        # These are not replaceable with CHECK_LE, so bail out early.
+        return
+      elif token in ('<<', '<<=', '>>', '>>=', '->*', '->'):
+        # Non-relational operator
+        lhs += token
+        expression = matched.group(2)
+      else:
+        # Relational operator
+        operator = token
+        rhs = matched.group(2)
+        break
+    else:
+      # Unparenthesized operand.  Instead of appending to lhs one character
+      # at a time, we do another regular expression match to consume several
+      # characters at once if possible.  Trivial benchmark shows that this
+      # is more efficient when the operands are longer than a single
+      # character, which is generally the case.
+      matched = Match(r'^([^-=!<>()&|]+)(.*)$', expression)
+      if not matched:
+        matched = Match(r'^(\s*\S)(.*)$', expression)
+        if not matched:
+          break
+      lhs += matched.group(1)
+      expression = matched.group(2)
+
+  # Only apply checks if we got all parts of the boolean expression
+  if not (lhs and operator and rhs):
+    return
+
+  # Check that rhs do not contain logical operators.  We already know
+  # that lhs is fine since the loop above parses out && and ||.
+  if rhs.find('&&') > -1 or rhs.find('||') > -1:
+    return
+
+  # At least one of the operands must be a constant literal.  This is
+  # to avoid suggesting replacements for unprintable things like
+  # CHECK(variable != iterator)
+  #
+  # The following pattern matches decimal, hex integers, strings, and
+  # characters (in that order).
+  lhs = lhs.strip()
+  rhs = rhs.strip()
+  match_constant = r'^([-+]?(\d+|0[xX][0-9a-fA-F]+)[lLuU]{0,3}|".*"|\'.*\')$'
+  if Match(match_constant, lhs) or Match(match_constant, rhs):
+    # Note: since we know both lhs and rhs, we can provide a more
+    # descriptive error message like:
+    #   Consider using CHECK_EQ(x, 42) instead of CHECK(x == 42)
+    # Instead of:
+    #   Consider using CHECK_EQ instead of CHECK(a == b)
+    #
+    # We are still keeping the less descriptive message because if lhs
+    # or rhs gets long, the error message might become unreadable.
+    error(filename, linenum, 'readability/check', 2,
+          'Consider using %s instead of %s(a %s b)' % (
+              _CHECK_REPLACEMENT[check_macro][operator],
+              check_macro, operator))
+
+
+def CheckAltTokens(filename, clean_lines, linenum, error):
+  """Check alternative keywords being used in boolean expressions.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    error: The function to call with any errors found.
+  """
+  line = clean_lines.elided[linenum]
+
+  # Avoid preprocessor lines
+  if Match(r'^\s*#', line):
+    return
+
+  # Last ditch effort to avoid multi-line comments.  This will not help
+  # if the comment started before the current line or ended after the
+  # current line, but it catches most of the false positives.  At least,
+  # it provides a way to workaround this warning for people who use
+  # multi-line comments in preprocessor macros.
+  #
+  # TODO(unknown): remove this once cpplint has better support for
+  # multi-line comments.
+  if line.find('/*') >= 0 or line.find('*/') >= 0:
+    return
+
+  for match in _ALT_TOKEN_REPLACEMENT_PATTERN.finditer(line):
+    error(filename, linenum, 'readability/alt_tokens', 2,
+          'Use operator %s instead of %s' % (
+              _ALT_TOKEN_REPLACEMENT[match.group(1)], match.group(1)))
+
+
+def GetLineWidth(line):
+  """Determines the width of the line in column positions.
+
+  Args:
+    line: A string, which may be a Unicode string.
+
+  Returns:
+    The width of the line in column positions, accounting for Unicode
+    combining characters and wide characters.
+  """
+  if isinstance(line, unicode):
+    width = 0
+    for uc in unicodedata.normalize('NFC', line):
+      if unicodedata.east_asian_width(uc) in ('W', 'F'):
+        width += 2
+      elif not unicodedata.combining(uc):
+        width += 1
+    return width
+  else:
+    return len(line)
+
+
+def CheckStyle(filename, clean_lines, linenum, file_extension, nesting_state,
+               error):
+  """Checks rules from the 'C++ style rules' section of cppguide.html.
+
+  Most of these rules are hard to test (naming, comment style), but we
+  do what we can.  In particular we check for 2-space indents, line lengths,
+  tab usage, spaces inside code, etc.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    file_extension: The extension (without the dot) of the filename.
+    nesting_state: A NestingState instance which maintains information about
+                   the current stack of nested blocks being parsed.
+    error: The function to call with any errors found.
+  """
+
+  # Don't use "elided" lines here, otherwise we can't check commented lines.
+  # Don't want to use "raw" either, because we don't want to check inside C++11
+  # raw strings,
+  raw_lines = clean_lines.lines_without_raw_strings
+  line = raw_lines[linenum]
+
+  if line.find('\t') != -1:
+    error(filename, linenum, 'whitespace/tab', 1,
+          'Tab found; better to use spaces')
+
+  # One or three blank spaces at the beginning of the line is weird; it's
+  # hard to reconcile that with 2-space indents.
+  # NOTE: here are the conditions rob pike used for his tests.  Mine aren't
+  # as sophisticated, but it may be worth becoming so:  RLENGTH==initial_spaces
+  # if(RLENGTH > 20) complain = 0;
+  # if(match($0, " +(error|private|public|protected):")) complain = 0;
+  # if(match(prev, "&& *$")) complain = 0;
+  # if(match(prev, "\\|\\| *$")) complain = 0;
+  # if(match(prev, "[\",=><] *$")) complain = 0;
+  # if(match($0, " <<")) complain = 0;
+  # if(match(prev, " +for \\(")) complain = 0;
+  # if(prevodd && match(prevprev, " +for \\(")) complain = 0;
+  scope_or_label_pattern = r'\s*\w+\s*:\s*\\?$'
+  classinfo = nesting_state.InnermostClass()
+  initial_spaces = 0
+  cleansed_line = clean_lines.elided[linenum]
+  while initial_spaces < len(line) and line[initial_spaces] == ' ':
+    initial_spaces += 1
+  if line and line[-1].isspace():
+    error(filename, linenum, 'whitespace/end_of_line', 4,
+          'Line ends in whitespace.  Consider deleting these extra spaces.')
+  # There are certain situations we allow one space, notably for
+  # section labels, and also lines containing multi-line raw strings.
+  elif ((initial_spaces == 1 or initial_spaces == 3) and
+        not Match(scope_or_label_pattern, cleansed_line) and
+        not (clean_lines.raw_lines[linenum] != line and
+             Match(r'^\s*""', line))):
+    error(filename, linenum, 'whitespace/indent', 3,
+          'Weird number of spaces at line-start.  '
+          'Are you using a 2-space indent?')
+
+  # Check if the line is a header guard.
+  is_header_guard = False
+  if file_extension == 'h':
+    cppvar = GetHeaderGuardCPPVariable(filename)
+    if (line.startswith('#ifndef %s' % cppvar) or
+        line.startswith('#define %s' % cppvar) or
+        line.startswith('#endif  // %s' % cppvar)):
+      is_header_guard = True
+  # #include lines and header guards can be long, since there's no clean way to
+  # split them.
+  #
+  # URLs can be long too.  It's possible to split these, but it makes them
+  # harder to cut&paste.
+  #
+  # The "$Id:...$" comment may also get very long without it being the
+  # developers fault.
+  if (not line.startswith('#include') and not is_header_guard and
+      not Match(r'^\s*//.*http(s?)://\S*$', line) and
+      not Match(r'^// \$Id:.*#[0-9]+ \$$', line)):
+    line_width = GetLineWidth(line)
+    extended_length = int((_line_length * 1.25))
+    if line_width > extended_length:
+      error(filename, linenum, 'whitespace/line_length', 4,
+            'Lines should very rarely be longer than %i characters' %
+            extended_length)
+    elif line_width > _line_length:
+      error(filename, linenum, 'whitespace/line_length', 2,
+            'Lines should be <= %i characters long' % _line_length)
+
+  if (cleansed_line.count(';') > 1 and
+      # for loops are allowed two ;'s (and may run over two lines).
+      cleansed_line.find('for') == -1 and
+      (GetPreviousNonBlankLine(clean_lines, linenum)[0].find('for') == -1 or
+       GetPreviousNonBlankLine(clean_lines, linenum)[0].find(';') != -1) and
+      # It's ok to have many commands in a switch case that fits in 1 line
+      not ((cleansed_line.find('case ') != -1 or
+            cleansed_line.find('default:') != -1) and
+           cleansed_line.find('break;') != -1)):
+    error(filename, linenum, 'whitespace/newline', 0,
+          'More than one command on the same line')
+
+  # Some more style checks
+  CheckBraces(filename, clean_lines, linenum, error)
+  CheckTrailingSemicolon(filename, clean_lines, linenum, error)
+  CheckEmptyBlockBody(filename, clean_lines, linenum, error)
+  CheckAccess(filename, clean_lines, linenum, nesting_state, error)
+  CheckSpacing(filename, clean_lines, linenum, nesting_state, error)
+  CheckOperatorSpacing(filename, clean_lines, linenum, error)
+  CheckParenthesisSpacing(filename, clean_lines, linenum, error)
+  CheckCommaSpacing(filename, clean_lines, linenum, error)
+  CheckBracesSpacing(filename, clean_lines, linenum, error)
+  CheckSpacingForFunctionCall(filename, clean_lines, linenum, error)
+  CheckRValueReference(filename, clean_lines, linenum, nesting_state, error)
+  CheckCheck(filename, clean_lines, linenum, error)
+  CheckAltTokens(filename, clean_lines, linenum, error)
+  classinfo = nesting_state.InnermostClass()
+  if classinfo:
+    CheckSectionSpacing(filename, clean_lines, classinfo, linenum, error)
+
+
+_RE_PATTERN_INCLUDE = re.compile(r'^\s*#\s*include\s*([<"])([^>"]*)[>"].*$')
+# Matches the first component of a filename delimited by -s and _s. That is:
+#  _RE_FIRST_COMPONENT.match('foo').group(0) == 'foo'
+#  _RE_FIRST_COMPONENT.match('foo.cc').group(0) == 'foo'
+#  _RE_FIRST_COMPONENT.match('foo-bar_baz.cc').group(0) == 'foo'
+#  _RE_FIRST_COMPONENT.match('foo_bar-baz.cc').group(0) == 'foo'
+_RE_FIRST_COMPONENT = re.compile(r'^[^-_.]+')
+
+
+def _DropCommonSuffixes(filename):
+  """Drops common suffixes like _test.cc or -inl.h from filename.
+
+  For example:
+    >>> _DropCommonSuffixes('foo/foo-inl.h')
+    'foo/foo'
+    >>> _DropCommonSuffixes('foo/bar/foo.cc')
+    'foo/bar/foo'
+    >>> _DropCommonSuffixes('foo/foo_internal.h')
+    'foo/foo'
+    >>> _DropCommonSuffixes('foo/foo_unusualinternal.h')
+    'foo/foo_unusualinternal'
+
+  Args:
+    filename: The input filename.
+
+  Returns:
+    The filename with the common suffix removed.
+  """
+  for suffix in ('test.cc', 'regtest.cc', 'unittest.cc',
+                 'inl.h', 'impl.h', 'internal.h'):
+    if (filename.endswith(suffix) and len(filename) > len(suffix) and
+        filename[-len(suffix) - 1] in ('-', '_')):
+      return filename[:-len(suffix) - 1]
+  return os.path.splitext(filename)[0]
+
+
+def _IsTestFilename(filename):
+  """Determines if the given filename has a suffix that identifies it as a test.
+
+  Args:
+    filename: The input filename.
+
+  Returns:
+    True if 'filename' looks like a test, False otherwise.
+  """
+  if (filename.endswith('_test.cc') or
+      filename.endswith('_unittest.cc') or
+      filename.endswith('_regtest.cc')):
+    return True
+  else:
+    return False
+
+
+def _ClassifyInclude(fileinfo, include, is_system):
+  """Figures out what kind of header 'include' is.
+
+  Args:
+    fileinfo: The current file cpplint is running over. A FileInfo instance.
+    include: The path to a #included file.
+    is_system: True if the #include used <> rather than "".
+
+  Returns:
+    One of the _XXX_HEADER constants.
+
+  For example:
+    >>> _ClassifyInclude(FileInfo('foo/foo.cc'), 'stdio.h', True)
+    _C_SYS_HEADER
+    >>> _ClassifyInclude(FileInfo('foo/foo.cc'), 'string', True)
+    _CPP_SYS_HEADER
+    >>> _ClassifyInclude(FileInfo('foo/foo.cc'), 'foo/foo.h', False)
+    _LIKELY_MY_HEADER
+    >>> _ClassifyInclude(FileInfo('foo/foo_unknown_extension.cc'),
+    ...                  'bar/foo_other_ext.h', False)
+    _POSSIBLE_MY_HEADER
+    >>> _ClassifyInclude(FileInfo('foo/foo.cc'), 'foo/bar.h', False)
+    _OTHER_HEADER
+  """
+  # This is a list of all standard c++ header files, except
+  # those already checked for above.
+  is_cpp_h = include in _CPP_HEADERS
+
+  if is_system:
+    if is_cpp_h:
+      return _CPP_SYS_HEADER
+    else:
+      return _C_SYS_HEADER
+
+  # If the target file and the include we're checking share a
+  # basename when we drop common extensions, and the include
+  # lives in . , then it's likely to be owned by the target file.
+  target_dir, target_base = (
+      os.path.split(_DropCommonSuffixes(fileinfo.RepositoryName())))
+  include_dir, include_base = os.path.split(_DropCommonSuffixes(include))
+  if target_base == include_base and (
+      include_dir == target_dir or
+      include_dir == os.path.normpath(target_dir + '/../public')):
+    return _LIKELY_MY_HEADER
+
+  # If the target and include share some initial basename
+  # component, it's possible the target is implementing the
+  # include, so it's allowed to be first, but we'll never
+  # complain if it's not there.
+  target_first_component = _RE_FIRST_COMPONENT.match(target_base)
+  include_first_component = _RE_FIRST_COMPONENT.match(include_base)
+  if (target_first_component and include_first_component and
+      target_first_component.group(0) ==
+      include_first_component.group(0)):
+    return _POSSIBLE_MY_HEADER
+
+  return _OTHER_HEADER
+
+
+
+def CheckIncludeLine(filename, clean_lines, linenum, include_state, error):
+  """Check rules that are applicable to #include lines.
+
+  Strings on #include lines are NOT removed from elided line, to make
+  certain tasks easier. However, to prevent false positives, checks
+  applicable to #include lines in CheckLanguage must be put here.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    include_state: An _IncludeState instance in which the headers are inserted.
+    error: The function to call with any errors found.
+  """
+  fileinfo = FileInfo(filename)
+  line = clean_lines.lines[linenum]
+
+  # "include" should use the new style "foo/bar.h" instead of just "bar.h"
+  # Only do this check if the included header follows google naming
+  # conventions.  If not, assume that it's a 3rd party API that
+  # requires special include conventions.
+  #
+  # We also make an exception for Lua headers, which follow google
+  # naming convention but not the include convention.
+  match = Match(r'#include\s*"([^/]+\.h)"', line)
+  if match and not _THIRD_PARTY_HEADERS_PATTERN.match(match.group(1)):
+    error(filename, linenum, 'build/include', 4,
+          'Include the directory when naming .h files')
+
+  # we shouldn't include a file more than once. actually, there are a
+  # handful of instances where doing so is okay, but in general it's
+  # not.
+  match = _RE_PATTERN_INCLUDE.search(line)
+  if match:
+    include = match.group(2)
+    is_system = (match.group(1) == '<')
+    duplicate_line = include_state.FindHeader(include)
+    if duplicate_line >= 0:
+      error(filename, linenum, 'build/include', 4,
+            '"%s" already included at %s:%s' %
+            (include, filename, duplicate_line))
+    elif (include.endswith('.cc') and
+          os.path.dirname(fileinfo.RepositoryName()) != os.path.dirname(include)):
+      error(filename, linenum, 'build/include', 4,
+            'Do not include .cc files from other packages')
+    elif not _THIRD_PARTY_HEADERS_PATTERN.match(include):
+      include_state.include_list[-1].append((include, linenum))
+
+      # We want to ensure that headers appear in the right order:
+      # 1) for foo.cc, foo.h  (preferred location)
+      # 2) c system files
+      # 3) cpp system files
+      # 4) for foo.cc, foo.h  (deprecated location)
+      # 5) other google headers
+      #
+      # We classify each include statement as one of those 5 types
+      # using a number of techniques. The include_state object keeps
+      # track of the highest type seen, and complains if we see a
+      # lower type after that.
+      error_message = include_state.CheckNextIncludeOrder(
+          _ClassifyInclude(fileinfo, include, is_system))
+      if error_message:
+        error(filename, linenum, 'build/include_order', 4,
+              '%s. Should be: %s.h, c system, c++ system, other.' %
+              (error_message, fileinfo.BaseName()))
+      canonical_include = include_state.CanonicalizeAlphabeticalOrder(include)
+      if not include_state.IsInAlphabeticalOrder(
+          clean_lines, linenum, canonical_include):
+        error(filename, linenum, 'build/include_alpha', 4,
+              'Include "%s" not in alphabetical order' % include)
+      include_state.SetLastHeader(canonical_include)
+
+
+
+def _GetTextInside(text, start_pattern):
+  r"""Retrieves all the text between matching open and close parentheses.
+
+  Given a string of lines and a regular expression string, retrieve all the text
+  following the expression and between opening punctuation symbols like
+  (, [, or {, and the matching close-punctuation symbol. This properly nested
+  occurrences of the punctuations, so for the text like
+    printf(a(), b(c()));
+  a call to _GetTextInside(text, r'printf\(') will return 'a(), b(c())'.
+  start_pattern must match string having an open punctuation symbol at the end.
+
+  Args:
+    text: The lines to extract text. Its comments and strings must be elided.
+           It can be single line and can span multiple lines.
+    start_pattern: The regexp string indicating where to start extracting
+                   the text.
+  Returns:
+    The extracted text.
+    None if either the opening string or ending punctuation could not be found.
+  """
+  # TODO(unknown): Audit cpplint.py to see what places could be profitably
+  # rewritten to use _GetTextInside (and use inferior regexp matching today).
+
+  # Give opening punctuations to get the matching close-punctuations.
+  matching_punctuation = {'(': ')', '{': '}', '[': ']'}
+  closing_punctuation = set(matching_punctuation.itervalues())
+
+  # Find the position to start extracting text.
+  match = re.search(start_pattern, text, re.M)
+  if not match:  # start_pattern not found in text.
+    return None
+  start_position = match.end(0)
+
+  assert start_position > 0, (
+      'start_pattern must ends with an opening punctuation.')
+  assert text[start_position - 1] in matching_punctuation, (
+      'start_pattern must ends with an opening punctuation.')
+  # Stack of closing punctuations we expect to have in text after position.
+  punctuation_stack = [matching_punctuation[text[start_position - 1]]]
+  position = start_position
+  while punctuation_stack and position < len(text):
+    if text[position] == punctuation_stack[-1]:
+      punctuation_stack.pop()
+    elif text[position] in closing_punctuation:
+      # A closing punctuation without matching opening punctuations.
+      return None
+    elif text[position] in matching_punctuation:
+      punctuation_stack.append(matching_punctuation[text[position]])
+    position += 1
+  if punctuation_stack:
+    # Opening punctuations left without matching close-punctuations.
+    return None
+  # punctuations match.
+  return text[start_position:position - 1]
+
+
+# Patterns for matching call-by-reference parameters.
+#
+# Supports nested templates up to 2 levels deep using this messy pattern:
+#   < (?: < (?: < [^<>]*
+#               >
+#           |   [^<>] )*
+#         >
+#     |   [^<>] )*
+#   >
+_RE_PATTERN_IDENT = r'[_a-zA-Z]\w*'  # =~ [[:alpha:]][[:alnum:]]*
+_RE_PATTERN_TYPE = (
+    r'(?:const\s+)?(?:typename\s+|class\s+|struct\s+|union\s+|enum\s+)?'
+    r'(?:\w|'
+    r'\s*<(?:<(?:<[^<>]*>|[^<>])*>|[^<>])*>|'
+    r'::)+')
+# A call-by-reference parameter ends with '& identifier'.
+_RE_PATTERN_REF_PARAM = re.compile(
+    r'(' + _RE_PATTERN_TYPE + r'(?:\s*(?:\bconst\b|[*]))*\s*'
+    r'&\s*' + _RE_PATTERN_IDENT + r')\s*(?:=[^,()]+)?[,)]')
+# A call-by-const-reference parameter either ends with 'const& identifier'
+# or looks like 'const type& identifier' when 'type' is atomic.
+_RE_PATTERN_CONST_REF_PARAM = (
+    r'(?:.*\s*\bconst\s*&\s*' + _RE_PATTERN_IDENT +
+    r'|const\s+' + _RE_PATTERN_TYPE + r'\s*&\s*' + _RE_PATTERN_IDENT + r')')
+
+
+def CheckLanguage(filename, clean_lines, linenum, file_extension,
+                  include_state, nesting_state, error):
+  """Checks rules from the 'C++ language rules' section of cppguide.html.
+
+  Some of these rules are hard to test (function overloading, using
+  uint32 inappropriately), but we do the best we can.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    file_extension: The extension (without the dot) of the filename.
+    include_state: An _IncludeState instance in which the headers are inserted.
+    nesting_state: A NestingState instance which maintains information about
+                   the current stack of nested blocks being parsed.
+    error: The function to call with any errors found.
+  """
+  # If the line is empty or consists of entirely a comment, no need to
+  # check it.
+  line = clean_lines.elided[linenum]
+  if not line:
+    return
+
+  match = _RE_PATTERN_INCLUDE.search(line)
+  if match:
+    CheckIncludeLine(filename, clean_lines, linenum, include_state, error)
+    return
+
+  # Reset include state across preprocessor directives.  This is meant
+  # to silence warnings for conditional includes.
+  match = Match(r'^\s*#\s*(if|ifdef|ifndef|elif|else|endif)\b', line)
+  if match:
+    include_state.ResetSection(match.group(1))
+
+  # Make Windows paths like Unix.
+  fullname = os.path.abspath(filename).replace('\\', '/')
+  
+  # Perform other checks now that we are sure that this is not an include line
+  CheckCasts(filename, clean_lines, linenum, error)
+  CheckGlobalStatic(filename, clean_lines, linenum, error)
+  CheckPrintf(filename, clean_lines, linenum, error)
+
+  if file_extension == 'h':
+    # TODO(unknown): check that 1-arg constructors are explicit.
+    #                How to tell it's a constructor?
+    #                (handled in CheckForNonStandardConstructs for now)
+    # TODO(unknown): check that classes declare or disable copy/assign
+    #                (level 1 error)
+    pass
+
+  # Check if people are using the verboten C basic types.  The only exception
+  # we regularly allow is "unsigned short port" for port.
+  if Search(r'\bshort port\b', line):
+    if not Search(r'\bunsigned short port\b', line):
+      error(filename, linenum, 'runtime/int', 4,
+            'Use "unsigned short" for ports, not "short"')
+  else:
+    match = Search(r'\b(short|long(?! +double)|long long)\b', line)
+    if match:
+      error(filename, linenum, 'runtime/int', 4,
+            'Use int16/int64/etc, rather than the C type %s' % match.group(1))
+
+  # Check if some verboten operator overloading is going on
+  # TODO(unknown): catch out-of-line unary operator&:
+  #   class X {};
+  #   int operator&(const X& x) { return 42; }  // unary operator&
+  # The trick is it's hard to tell apart from binary operator&:
+  #   class Y { int operator&(const Y& x) { return 23; } }; // binary operator&
+  if Search(r'\boperator\s*&\s*\(\s*\)', line):
+    error(filename, linenum, 'runtime/operator', 4,
+          'Unary operator& is dangerous.  Do not use it.')
+
+  # Check for suspicious usage of "if" like
+  # } if (a == b) {
+  if Search(r'\}\s*if\s*\(', line):
+    error(filename, linenum, 'readability/braces', 4,
+          'Did you mean "else if"? If not, start a new line for "if".')
+
+  # Check for potential format string bugs like printf(foo).
+  # We constrain the pattern not to pick things like DocidForPrintf(foo).
+  # Not perfect but it can catch printf(foo.c_str()) and printf(foo->c_str())
+  # TODO(unknown): Catch the following case. Need to change the calling
+  # convention of the whole function to process multiple line to handle it.
+  #   printf(
+  #       boy_this_is_a_really_long_variable_that_cannot_fit_on_the_prev_line);
+  printf_args = _GetTextInside(line, r'(?i)\b(string)?printf\s*\(')
+  if printf_args:
+    match = Match(r'([\w.\->()]+)$', printf_args)
+    if match and match.group(1) != '__VA_ARGS__':
+      function_name = re.search(r'\b((?:string)?printf)\s*\(',
+                                line, re.I).group(1)
+      error(filename, linenum, 'runtime/printf', 4,
+            'Potential format string bug. Do %s("%%s", %s) instead.'
+            % (function_name, match.group(1)))
+
+  # Check for potential memset bugs like memset(buf, sizeof(buf), 0).
+  match = Search(r'memset\s*\(([^,]*),\s*([^,]*),\s*0\s*\)', line)
+  if match and not Match(r"^''|-?[0-9]+|0x[0-9A-Fa-f]$", match.group(2)):
+    error(filename, linenum, 'runtime/memset', 4,
+          'Did you mean "memset(%s, 0, %s)"?'
+          % (match.group(1), match.group(2)))
+
+  if Search(r'\busing namespace\b', line):
+    error(filename, linenum, 'build/namespaces', 5,
+          'Do not use namespace using-directives.  '
+          'Use using-declarations instead.')
+
+  # Detect variable-length arrays.
+  match = Match(r'\s*(.+::)?(\w+) [a-z]\w*\[(.+)];', line)
+  if (match and match.group(2) != 'return' and match.group(2) != 'delete' and
+      match.group(3).find(']') == -1):
+    # Split the size using space and arithmetic operators as delimiters.
+    # If any of the resulting tokens are not compile time constants then
+    # report the error.
+    tokens = re.split(r'\s|\+|\-|\*|\/|<<|>>]', match.group(3))
+    is_const = True
+    skip_next = False
+    for tok in tokens:
+      if skip_next:
+        skip_next = False
+        continue
+
+      if Search(r'sizeof\(.+\)', tok): continue
+      if Search(r'arraysize\(\w+\)', tok): continue
+
+      tok = tok.lstrip('(')
+      tok = tok.rstrip(')')
+      if not tok: continue
+      if Match(r'\d+', tok): continue
+      if Match(r'0[xX][0-9a-fA-F]+', tok): continue
+      if Match(r'k[A-Z0-9]\w*', tok): continue
+      if Match(r'(.+::)?k[A-Z0-9]\w*', tok): continue
+      if Match(r'(.+::)?[A-Z][A-Z0-9_]*', tok): continue
+      # A catch all for tricky sizeof cases, including 'sizeof expression',
+      # 'sizeof(*type)', 'sizeof(const type)', 'sizeof(struct StructName)'
+      # requires skipping the next token because we split on ' ' and '*'.
+      if tok.startswith('sizeof'):
+        skip_next = True
+        continue
+      is_const = False
+      break
+    if not is_const:
+      error(filename, linenum, 'runtime/arrays', 1,
+            'Do not use variable-length arrays.  Use an appropriately named '
+            "('k' followed by CamelCase) compile-time constant for the size.")
+
+  # Check for use of unnamed namespaces in header files.  Registration
+  # macros are typically OK, so we allow use of "namespace {" on lines
+  # that end with backslashes.
+  if (file_extension == 'h'
+      and Search(r'\bnamespace\s*{', line)
+      and line[-1] != '\\'):
+    error(filename, linenum, 'build/namespaces', 4,
+          'Do not use unnamed namespaces in header files.  See '
+          'http://google-styleguide.googlecode.com/svn/trunk/cppguide.xml#Namespaces'
+          ' for more information.')
+
+
+def CheckGlobalStatic(filename, clean_lines, linenum, error):
+  """Check for unsafe global or static objects.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    error: The function to call with any errors found.
+  """
+  line = clean_lines.elided[linenum]
+
+  # Match two lines at a time to support multiline declarations
+  if linenum + 1 < clean_lines.NumLines() and not Search(r'[;({]', line):
+    line += clean_lines.elided[linenum + 1].strip()
+
+  # Check for people declaring static/global STL strings at the top level.
+  # This is dangerous because the C++ language does not guarantee that
+  # globals with constructors are initialized before the first access.
+  match = Match(
+      r'((?:|static +)(?:|const +))string +([a-zA-Z0-9_:]+)\b(.*)',
+      line)
+
+  # Remove false positives:
+  # - String pointers (as opposed to values).
+  #    string *pointer
+  #    const string *pointer
+  #    string const *pointer
+  #    string *const pointer
+  #
+  # - Functions and template specializations.
+  #    string Function<Type>(...
+  #    string Class<Type>::Method(...
+  #
+  # - Operators.  These are matched separately because operator names
+  #   cross non-word boundaries, and trying to match both operators
+  #   and functions at the same time would decrease accuracy of
+  #   matching identifiers.
+  #    string Class::operator*()
+  if (match and
+      not Search(r'\bstring\b(\s+const)?\s*\*\s*(const\s+)?\w', line) and
+      not Search(r'\boperator\W', line) and
+      not Match(r'\s*(<.*>)?(::[a-zA-Z0-9_]+)*\s*\(([^"]|$)', match.group(3))):
+    error(filename, linenum, 'runtime/string', 4,
+          'For a static/global string constant, use a C style string instead: '
+          '"%schar %s[]".' %
+          (match.group(1), match.group(2)))
+
+  if Search(r'\b([A-Za-z0-9_]*_)\(\1\)', line):
+    error(filename, linenum, 'runtime/init', 4,
+          'You seem to be initializing a member variable with itself.')
+
+
+def CheckPrintf(filename, clean_lines, linenum, error):
+  """Check for printf related issues.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    error: The function to call with any errors found.
+  """
+  line = clean_lines.elided[linenum]
+
+  # When snprintf is used, the second argument shouldn't be a literal.
+  match = Search(r'snprintf\s*\(([^,]*),\s*([0-9]*)\s*,', line)
+  if match and match.group(2) != '0':
+    # If 2nd arg is zero, snprintf is used to calculate size.
+    error(filename, linenum, 'runtime/printf', 3,
+          'If you can, use sizeof(%s) instead of %s as the 2nd arg '
+          'to snprintf.' % (match.group(1), match.group(2)))
+
+  # Check if some verboten C functions are being used.
+  if Search(r'\bsprintf\s*\(', line):
+    error(filename, linenum, 'runtime/printf', 5,
+          'Never use sprintf. Use snprintf instead.')
+  match = Search(r'\b(strcpy|strcat)\s*\(', line)
+  if match:
+    error(filename, linenum, 'runtime/printf', 4,
+          'Almost always, snprintf is better than %s' % match.group(1))
+
+
+def IsDerivedFunction(clean_lines, linenum):
+  """Check if current line contains an inherited function.
+
+  Args:
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+  Returns:
+    True if current line contains a function with "override"
+    virt-specifier.
+  """
+  # Scan back a few lines for start of current function
+  for i in xrange(linenum, max(-1, linenum - 10), -1):
+    match = Match(r'^([^()]*\w+)\(', clean_lines.elided[i])
+    if match:
+      # Look for "override" after the matching closing parenthesis
+      line, _, closing_paren = CloseExpression(
+          clean_lines, i, len(match.group(1)))
+      return (closing_paren >= 0 and
+              Search(r'\boverride\b', line[closing_paren:]))
+  return False
+
+
+def IsOutOfLineMethodDefinition(clean_lines, linenum):
+  """Check if current line contains an out-of-line method definition.
+
+  Args:
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+  Returns:
+    True if current line contains an out-of-line method definition.
+  """
+  # Scan back a few lines for start of current function
+  for i in xrange(linenum, max(-1, linenum - 10), -1):
+    if Match(r'^([^()]*\w+)\(', clean_lines.elided[i]):
+      return Match(r'^[^()]*\w+::\w+\(', clean_lines.elided[i]) is not None
+  return False
+
+
+def IsInitializerList(clean_lines, linenum):
+  """Check if current line is inside constructor initializer list.
+
+  Args:
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+  Returns:
+    True if current line appears to be inside constructor initializer
+    list, False otherwise.
+  """
+  for i in xrange(linenum, 1, -1):
+    line = clean_lines.elided[i]
+    if i == linenum:
+      remove_function_body = Match(r'^(.*)\{\s*$', line)
+      if remove_function_body:
+        line = remove_function_body.group(1)
+
+    if Search(r'\s:\s*\w+[({]', line):
+      # A lone colon tend to indicate the start of a constructor
+      # initializer list.  It could also be a ternary operator, which
+      # also tend to appear in constructor initializer lists as
+      # opposed to parameter lists.
+      return True
+    if Search(r'\}\s*,\s*$', line):
+      # A closing brace followed by a comma is probably the end of a
+      # brace-initialized member in constructor initializer list.
+      return True
+    if Search(r'[{};]\s*$', line):
+      # Found one of the following:
+      # - A closing brace or semicolon, probably the end of the previous
+      #   function.
+      # - An opening brace, probably the start of current class or namespace.
+      #
+      # Current line is probably not inside an initializer list since
+      # we saw one of those things without seeing the starting colon.
+      return False
+
+  # Got to the beginning of the file without seeing the start of
+  # constructor initializer list.
+  return False
+
+
+def CheckForNonConstReference(filename, clean_lines, linenum,
+                              nesting_state, error):
+  """Check for non-const references.
+
+  Separate from CheckLanguage since it scans backwards from current
+  line, instead of scanning forward.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    nesting_state: A NestingState instance which maintains information about
+                   the current stack of nested blocks being parsed.
+    error: The function to call with any errors found.
+  """
+  # Do nothing if there is no '&' on current line.
+  line = clean_lines.elided[linenum]
+  if '&' not in line:
+    return
+
+  # If a function is inherited, current function doesn't have much of
+  # a choice, so any non-const references should not be blamed on
+  # derived function.
+  if IsDerivedFunction(clean_lines, linenum):
+    return
+
+  # Don't warn on out-of-line method definitions, as we would warn on the
+  # in-line declaration, if it isn't marked with 'override'.
+  if IsOutOfLineMethodDefinition(clean_lines, linenum):
+    return
+
+  # Long type names may be broken across multiple lines, usually in one
+  # of these forms:
+  #   LongType
+  #       ::LongTypeContinued &identifier
+  #   LongType::
+  #       LongTypeContinued &identifier
+  #   LongType<
+  #       ...>::LongTypeContinued &identifier
+  #
+  # If we detected a type split across two lines, join the previous
+  # line to current line so that we can match const references
+  # accordingly.
+  #
+  # Note that this only scans back one line, since scanning back
+  # arbitrary number of lines would be expensive.  If you have a type
+  # that spans more than 2 lines, please use a typedef.
+  if linenum > 1:
+    previous = None
+    if Match(r'\s*::(?:[\w<>]|::)+\s*&\s*\S', line):
+      # previous_line\n + ::current_line
+      previous = Search(r'\b((?:const\s*)?(?:[\w<>]|::)+[\w<>])\s*$',
+                        clean_lines.elided[linenum - 1])
+    elif Match(r'\s*[a-zA-Z_]([\w<>]|::)+\s*&\s*\S', line):
+      # previous_line::\n + current_line
+      previous = Search(r'\b((?:const\s*)?(?:[\w<>]|::)+::)\s*$',
+                        clean_lines.elided[linenum - 1])
+    if previous:
+      line = previous.group(1) + line.lstrip()
+    else:
+      # Check for templated parameter that is split across multiple lines
+      endpos = line.rfind('>')
+      if endpos > -1:
+        (_, startline, startpos) = ReverseCloseExpression(
+            clean_lines, linenum, endpos)
+        if startpos > -1 and startline < linenum:
+          # Found the matching < on an earlier line, collect all
+          # pieces up to current line.
+          line = ''
+          for i in xrange(startline, linenum + 1):
+            line += clean_lines.elided[i].strip()
+
+  # Check for non-const references in function parameters.  A single '&' may
+  # found in the following places:
+  #   inside expression: binary & for bitwise AND
+  #   inside expression: unary & for taking the address of something
+  #   inside declarators: reference parameter
+  # We will exclude the first two cases by checking that we are not inside a
+  # function body, including one that was just introduced by a trailing '{'.
+  # TODO(unknown): Doesn't account for 'catch(Exception& e)' [rare].
+  if (nesting_state.previous_stack_top and
+      not (isinstance(nesting_state.previous_stack_top, _ClassInfo) or
+           isinstance(nesting_state.previous_stack_top, _NamespaceInfo))):
+    # Not at toplevel, not within a class, and not within a namespace
+    return
+
+  # Avoid initializer lists.  We only need to scan back from the
+  # current line for something that starts with ':'.
+  #
+  # We don't need to check the current line, since the '&' would
+  # appear inside the second set of parentheses on the current line as
+  # opposed to the first set.
+  if linenum > 0:
+    for i in xrange(linenum - 1, max(0, linenum - 10), -1):
+      previous_line = clean_lines.elided[i]
+      if not Search(r'[),]\s*$', previous_line):
+        break
+      if Match(r'^\s*:\s+\S', previous_line):
+        return
+
+  # Avoid preprocessors
+  if Search(r'\\\s*$', line):
+    return
+
+  # Avoid constructor initializer lists
+  if IsInitializerList(clean_lines, linenum):
+    return
+
+  # We allow non-const references in a few standard places, like functions
+  # called "swap()" or iostream operators like "<<" or ">>".  Do not check
+  # those function parameters.
+  #
+  # We also accept & in static_assert, which looks like a function but
+  # it's actually a declaration expression.
+  whitelisted_functions = (r'(?:[sS]wap(?:<\w:+>)?|'
+                           r'operator\s*[<>][<>]|'
+                           r'static_assert|COMPILE_ASSERT'
+                           r')\s*\(')
+  if Search(whitelisted_functions, line):
+    return
+  elif not Search(r'\S+\([^)]*$', line):
+    # Don't see a whitelisted function on this line.  Actually we
+    # didn't see any function name on this line, so this is likely a
+    # multi-line parameter list.  Try a bit harder to catch this case.
+    for i in xrange(2):
+      if (linenum > i and
+          Search(whitelisted_functions, clean_lines.elided[linenum - i - 1])):
+        return
+
+  decls = ReplaceAll(r'{[^}]*}', ' ', line)  # exclude function body
+  for parameter in re.findall(_RE_PATTERN_REF_PARAM, decls):
+    if not Match(_RE_PATTERN_CONST_REF_PARAM, parameter):
+      error(filename, linenum, 'runtime/references', 2,
+            'Is this a non-const reference? '
+            'If so, make const or use a pointer: ' +
+            ReplaceAll(' *<', '<', parameter))
+
+
+def CheckCasts(filename, clean_lines, linenum, error):
+  """Various cast related checks.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    error: The function to call with any errors found.
+  """
+  line = clean_lines.elided[linenum]
+
+  # Check to see if they're using an conversion function cast.
+  # I just try to capture the most common basic types, though there are more.
+  # Parameterless conversion functions, such as bool(), are allowed as they are
+  # probably a member operator declaration or default constructor.
+  match = Search(
+      r'(\bnew\s+|\S<\s*(?:const\s+)?)?\b'
+      r'(int|float|double|bool|char|int32|uint32|int64|uint64)'
+      r'(\([^)].*)', line)
+  expecting_function = ExpectingFunctionArgs(clean_lines, linenum)
+  if match and not expecting_function:
+    matched_type = match.group(2)
+
+    # matched_new_or_template is used to silence two false positives:
+    # - New operators
+    # - Template arguments with function types
+    #
+    # For template arguments, we match on types immediately following
+    # an opening bracket without any spaces.  This is a fast way to
+    # silence the common case where the function type is the first
+    # template argument.  False negative with less-than comparison is
+    # avoided because those operators are usually followed by a space.
+    #
+    #   function<double(double)>   // bracket + no space = false positive
+    #   value < double(42)         // bracket + space = true positive
+    matched_new_or_template = match.group(1)
+
+    # Avoid arrays by looking for brackets that come after the closing
+    # parenthesis.
+    if Match(r'\([^()]+\)\s*\[', match.group(3)):
+      return
+
+    # Other things to ignore:
+    # - Function pointers
+    # - Casts to pointer types
+    # - Placement new
+    # - Alias declarations
+    matched_funcptr = match.group(3)
+    if (matched_new_or_template is None and
+        not (matched_funcptr and
+             (Match(r'\((?:[^() ]+::\s*\*\s*)?[^() ]+\)\s*\(',
+                    matched_funcptr) or
+              matched_funcptr.startswith('(*)'))) and
+        not Match(r'\s*using\s+\S+\s*=\s*' + matched_type, line) and
+        not Search(r'new\(\S+\)\s*' + matched_type, line)):
+      error(filename, linenum, 'readability/casting', 4,
+            'Using deprecated casting style.  '
+            'Use static_cast<%s>(...) instead' %
+            matched_type)
+
+  if not expecting_function:
+    CheckCStyleCast(filename, clean_lines, linenum, 'static_cast',
+                    r'\((int|float|double|bool|char|u?int(16|32|64))\)', error)
+
+  # This doesn't catch all cases. Consider (const char * const)"hello".
+  #
+  # (char *) "foo" should always be a const_cast (reinterpret_cast won't
+  # compile).
+  if CheckCStyleCast(filename, clean_lines, linenum, 'const_cast',
+                     r'\((char\s?\*+\s?)\)\s*"', error):
+    pass
+  else:
+    # Check pointer casts for other than string constants
+    CheckCStyleCast(filename, clean_lines, linenum, 'reinterpret_cast',
+                    r'\((\w+\s?\*+\s?)\)', error)
+
+  # In addition, we look for people taking the address of a cast.  This
+  # is dangerous -- casts can assign to temporaries, so the pointer doesn't
+  # point where you think.
+  #
+  # Some non-identifier character is required before the '&' for the
+  # expression to be recognized as a cast.  These are casts:
+  #   expression = &static_cast<int*>(temporary());
+  #   function(&(int*)(temporary()));
+  #
+  # This is not a cast:
+  #   reference_type&(int* function_param);
+  match = Search(
+      r'(?:[^\w]&\(([^)*][^)]*)\)[\w(])|'
+      r'(?:[^\w]&(static|dynamic|down|reinterpret)_cast\b)', line)
+  if match:
+    # Try a better error message when the & is bound to something
+    # dereferenced by the casted pointer, as opposed to the casted
+    # pointer itself.
+    parenthesis_error = False
+    match = Match(r'^(.*&(?:static|dynamic|down|reinterpret)_cast\b)<', line)
+    if match:
+      _, y1, x1 = CloseExpression(clean_lines, linenum, len(match.group(1)))
+      if x1 >= 0 and clean_lines.elided[y1][x1] == '(':
+        _, y2, x2 = CloseExpression(clean_lines, y1, x1)
+        if x2 >= 0:
+          extended_line = clean_lines.elided[y2][x2:]
+          if y2 < clean_lines.NumLines() - 1:
+            extended_line += clean_lines.elided[y2 + 1]
+          if Match(r'\s*(?:->|\[)', extended_line):
+            parenthesis_error = True
+
+    if parenthesis_error:
+      error(filename, linenum, 'readability/casting', 4,
+            ('Are you taking an address of something dereferenced '
+             'from a cast?  Wrapping the dereferenced expression in '
+             'parentheses will make the binding more obvious'))
+    else:
+      error(filename, linenum, 'runtime/casting', 4,
+            ('Are you taking an address of a cast?  '
+             'This is dangerous: could be a temp var.  '
+             'Take the address before doing the cast, rather than after'))
+
+
+def CheckCStyleCast(filename, clean_lines, linenum, cast_type, pattern, error):
+  """Checks for a C-style cast by looking for the pattern.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    cast_type: The string for the C++ cast to recommend.  This is either
+      reinterpret_cast, static_cast, or const_cast, depending.
+    pattern: The regular expression used to find C-style casts.
+    error: The function to call with any errors found.
+
+  Returns:
+    True if an error was emitted.
+    False otherwise.
+  """
+  line = clean_lines.elided[linenum]
+  match = Search(pattern, line)
+  if not match:
+    return False
+
+  # Exclude lines with keywords that tend to look like casts
+  context = line[0:match.start(1) - 1]
+  if Match(r'.*\b(?:sizeof|alignof|alignas|[_A-Z][_A-Z0-9]*)\s*$', context):
+    return False
+
+  # Try expanding current context to see if we one level of
+  # parentheses inside a macro.
+  if linenum > 0:
+    for i in xrange(linenum - 1, max(0, linenum - 5), -1):
+      context = clean_lines.elided[i] + context
+  if Match(r'.*\b[_A-Z][_A-Z0-9]*\s*\((?:\([^()]*\)|[^()])*$', context):
+    return False
+
+  # operator++(int) and operator--(int)
+  if context.endswith(' operator++') or context.endswith(' operator--'):
+    return False
+
+  # A single unnamed argument for a function tends to look like old
+  # style cast.  If we see those, don't issue warnings for deprecated
+  # casts, instead issue warnings for unnamed arguments where
+  # appropriate.
+  #
+  # These are things that we want warnings for, since the style guide
+  # explicitly require all parameters to be named:
+  #   Function(int);
+  #   Function(int) {
+  #   ConstMember(int) const;
+  #   ConstMember(int) const {
+  #   ExceptionMember(int) throw (...);
+  #   ExceptionMember(int) throw (...) {
+  #   PureVirtual(int) = 0;
+  #   [](int) -> bool {
+  #
+  # These are functions of some sort, where the compiler would be fine
+  # if they had named parameters, but people often omit those
+  # identifiers to reduce clutter:
+  #   (FunctionPointer)(int);
+  #   (FunctionPointer)(int) = value;
+  #   Function((function_pointer_arg)(int))
+  #   Function((function_pointer_arg)(int), int param)
+  #   <TemplateArgument(int)>;
+  #   <(FunctionPointerTemplateArgument)(int)>;
+  remainder = line[match.end(0):]
+  if Match(r'^\s*(?:;|const\b|throw\b|final\b|override\b|[=>{),]|->)',
+           remainder):
+    # Looks like an unnamed parameter.
+
+    # Don't warn on any kind of template arguments.
+    if Match(r'^\s*>', remainder):
+      return False
+
+    # Don't warn on assignments to function pointers, but keep warnings for
+    # unnamed parameters to pure virtual functions.  Note that this pattern
+    # will also pass on assignments of "0" to function pointers, but the
+    # preferred values for those would be "nullptr" or "NULL".
+    matched_zero = Match(r'^\s=\s*(\S+)\s*;', remainder)
+    if matched_zero and matched_zero.group(1) != '0':
+      return False
+
+    # Don't warn on function pointer declarations.  For this we need
+    # to check what came before the "(type)" string.
+    if Match(r'.*\)\s*$', line[0:match.start(0)]):
+      return False
+
+    # Don't warn if the parameter is named with block comments, e.g.:
+    #  Function(int /*unused_param*/);
+    raw_line = clean_lines.raw_lines[linenum]
+    if '/*' in raw_line:
+      return False
+
+    # Passed all filters, issue warning here.
+    error(filename, linenum, 'readability/function', 3,
+          'All parameters should be named in a function')
+    return True
+
+  # At this point, all that should be left is actual casts.
+  error(filename, linenum, 'readability/casting', 4,
+        'Using C-style cast.  Use %s<%s>(...) instead' %
+        (cast_type, match.group(1)))
+
+  return True
+
+
+def ExpectingFunctionArgs(clean_lines, linenum):
+  """Checks whether where function type arguments are expected.
+
+  Args:
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+
+  Returns:
+    True if the line at 'linenum' is inside something that expects arguments
+    of function types.
+  """
+  line = clean_lines.elided[linenum]
+  return (Match(r'^\s*MOCK_(CONST_)?METHOD\d+(_T)?\(', line) or
+          (linenum >= 2 and
+           (Match(r'^\s*MOCK_(?:CONST_)?METHOD\d+(?:_T)?\((?:\S+,)?\s*$',
+                  clean_lines.elided[linenum - 1]) or
+            Match(r'^\s*MOCK_(?:CONST_)?METHOD\d+(?:_T)?\(\s*$',
+                  clean_lines.elided[linenum - 2]) or
+            Search(r'\bstd::m?function\s*\<\s*$',
+                   clean_lines.elided[linenum - 1]))))
+
+
+_HEADERS_CONTAINING_TEMPLATES = (
+    ('<deque>', ('deque',)),
+    ('<functional>', ('unary_function', 'binary_function',
+                      'plus', 'minus', 'multiplies', 'divides', 'modulus',
+                      'negate',
+                      'equal_to', 'not_equal_to', 'greater', 'less',
+                      'greater_equal', 'less_equal',
+                      'logical_and', 'logical_or', 'logical_not',
+                      'unary_negate', 'not1', 'binary_negate', 'not2',
+                      'bind1st', 'bind2nd',
+                      'pointer_to_unary_function',
+                      'pointer_to_binary_function',
+                      'ptr_fun',
+                      'mem_fun_t', 'mem_fun', 'mem_fun1_t', 'mem_fun1_ref_t',
+                      'mem_fun_ref_t',
+                      'const_mem_fun_t', 'const_mem_fun1_t',
+                      'const_mem_fun_ref_t', 'const_mem_fun1_ref_t',
+                      'mem_fun_ref',
+                     )),
+    ('<limits>', ('numeric_limits',)),
+    ('<list>', ('list',)),
+    ('<map>', ('map', 'multimap',)),
+    ('<memory>', ('allocator',)),
+    ('<queue>', ('queue', 'priority_queue',)),
+    ('<set>', ('set', 'multiset',)),
+    ('<stack>', ('stack',)),
+    ('<string>', ('char_traits', 'basic_string',)),
+    ('<tuple>', ('tuple',)),
+    ('<utility>', ('pair',)),
+    ('<vector>', ('vector',)),
+
+    # gcc extensions.
+    # Note: std::hash is their hash, ::hash is our hash
+    ('<hash_map>', ('hash_map', 'hash_multimap',)),
+    ('<hash_set>', ('hash_set', 'hash_multiset',)),
+    ('<slist>', ('slist',)),
+    )
+
+_RE_PATTERN_STRING = re.compile(r'\bstring\b')
+
+_re_pattern_algorithm_header = []
+for _template in ('copy', 'max', 'min', 'min_element', 'sort', 'swap',
+                  'transform'):
+  # Match max<type>(..., ...), max(..., ...), but not foo->max, foo.max or
+  # type::max().
+  _re_pattern_algorithm_header.append(
+      (re.compile(r'[^>.]\b' + _template + r'(<.*?>)?\([^\)]'),
+       _template,
+       '<algorithm>'))
+
+_re_pattern_templates = []
+for _header, _templates in _HEADERS_CONTAINING_TEMPLATES:
+  for _template in _templates:
+    _re_pattern_templates.append(
+        (re.compile(r'(\<|\b)' + _template + r'\s*\<'),
+         _template + '<>',
+         _header))
+
+
+def FilesBelongToSameModule(filename_cc, filename_h):
+  """Check if these two filenames belong to the same module.
+
+  The concept of a 'module' here is a as follows:
+  foo.h, foo-inl.h, foo.cc, foo_test.cc and foo_unittest.cc belong to the
+  same 'module' if they are in the same directory.
+  some/path/public/xyzzy and some/path/internal/xyzzy are also considered
+  to belong to the same module here.
+
+  If the filename_cc contains a longer path than the filename_h, for example,
+  '/absolute/path/to/base/sysinfo.cc', and this file would include
+  'base/sysinfo.h', this function also produces the prefix needed to open the
+  header. This is used by the caller of this function to more robustly open the
+  header file. We don't have access to the real include paths in this context,
+  so we need this guesswork here.
+
+  Known bugs: tools/base/bar.cc and base/bar.h belong to the same module
+  according to this implementation. Because of this, this function gives
+  some false positives. This should be sufficiently rare in practice.
+
+  Args:
+    filename_cc: is the path for the .cc file
+    filename_h: is the path for the header path
+
+  Returns:
+    Tuple with a bool and a string:
+    bool: True if filename_cc and filename_h belong to the same module.
+    string: the additional prefix needed to open the header file.
+  """
+
+  if not filename_cc.endswith('.cc'):
+    return (False, '')
+  filename_cc = filename_cc[:-len('.cc')]
+  if filename_cc.endswith('_unittest'):
+    filename_cc = filename_cc[:-len('_unittest')]
+  elif filename_cc.endswith('_test'):
+    filename_cc = filename_cc[:-len('_test')]
+  filename_cc = filename_cc.replace('/public/', '/')
+  filename_cc = filename_cc.replace('/internal/', '/')
+
+  if not filename_h.endswith('.h'):
+    return (False, '')
+  filename_h = filename_h[:-len('.h')]
+  if filename_h.endswith('-inl'):
+    filename_h = filename_h[:-len('-inl')]
+  filename_h = filename_h.replace('/public/', '/')
+  filename_h = filename_h.replace('/internal/', '/')
+
+  files_belong_to_same_module = filename_cc.endswith(filename_h)
+  common_path = ''
+  if files_belong_to_same_module:
+    common_path = filename_cc[:-len(filename_h)]
+  return files_belong_to_same_module, common_path
+
+
+def UpdateIncludeState(filename, include_dict, io=codecs):
+  """Fill up the include_dict with new includes found from the file.
+
+  Args:
+    filename: the name of the header to read.
+    include_dict: a dictionary in which the headers are inserted.
+    io: The io factory to use to read the file. Provided for testability.
+
+  Returns:
+    True if a header was successfully added. False otherwise.
+  """
+  headerfile = None
+  try:
+    headerfile = io.open(filename, 'r', 'utf8', 'replace')
+  except IOError:
+    return False
+  linenum = 0
+  for line in headerfile:
+    linenum += 1
+    clean_line = CleanseComments(line)
+    match = _RE_PATTERN_INCLUDE.search(clean_line)
+    if match:
+      include = match.group(2)
+      include_dict.setdefault(include, linenum)
+  return True
+
+
+def CheckForIncludeWhatYouUse(filename, clean_lines, include_state, error,
+                              io=codecs):
+  """Reports for missing stl includes.
+
+  This function will output warnings to make sure you are including the headers
+  necessary for the stl containers and functions that you use. We only give one
+  reason to include a header. For example, if you use both equal_to<> and
+  less<> in a .h file, only one (the latter in the file) of these will be
+  reported as a reason to include the <functional>.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    include_state: An _IncludeState instance.
+    error: The function to call with any errors found.
+    io: The IO factory to use to read the header file. Provided for unittest
+        injection.
+  """
+  required = {}  # A map of header name to linenumber and the template entity.
+                 # Example of required: { '<functional>': (1219, 'less<>') }
+
+  for linenum in xrange(clean_lines.NumLines()):
+    line = clean_lines.elided[linenum]
+    if not line or line[0] == '#':
+      continue
+
+    # String is special -- it is a non-templatized type in STL.
+    matched = _RE_PATTERN_STRING.search(line)
+    if matched:
+      # Don't warn about strings in non-STL namespaces:
+      # (We check only the first match per line; good enough.)
+      prefix = line[:matched.start()]
+      if prefix.endswith('std::') or not prefix.endswith('::'):
+        required['<string>'] = (linenum, 'string')
+
+    for pattern, template, header in _re_pattern_algorithm_header:
+      if pattern.search(line):
+        required[header] = (linenum, template)
+
+    # The following function is just a speed up, no semantics are changed.
+    if not '<' in line:  # Reduces the cpu time usage by skipping lines.
+      continue
+
+    for pattern, template, header in _re_pattern_templates:
+      if pattern.search(line):
+        required[header] = (linenum, template)
+
+  # The policy is that if you #include something in foo.h you don't need to
+  # include it again in foo.cc. Here, we will look at possible includes.
+  # Let's flatten the include_state include_list and copy it into a dictionary.
+  include_dict = dict([item for sublist in include_state.include_list
+                       for item in sublist])
+
+  # Did we find the header for this file (if any) and successfully load it?
+  header_found = False
+
+  # Use the absolute path so that matching works properly.
+  abs_filename = FileInfo(filename).FullName()
+
+  # For Emacs's flymake.
+  # If cpplint is invoked from Emacs's flymake, a temporary file is generated
+  # by flymake and that file name might end with '_flymake.cc'. In that case,
+  # restore original file name here so that the corresponding header file can be
+  # found.
+  # e.g. If the file name is 'foo_flymake.cc', we should search for 'foo.h'
+  # instead of 'foo_flymake.h'
+  abs_filename = re.sub(r'_flymake\.cc$', '.cc', abs_filename)
+
+  # include_dict is modified during iteration, so we iterate over a copy of
+  # the keys.
+  header_keys = include_dict.keys()
+  for header in header_keys:
+    (same_module, common_path) = FilesBelongToSameModule(abs_filename, header)
+    fullpath = common_path + header
+    if same_module and UpdateIncludeState(fullpath, include_dict, io):
+      header_found = True
+
+  # If we can't find the header file for a .cc, assume it's because we don't
+  # know where to look. In that case we'll give up as we're not sure they
+  # didn't include it in the .h file.
+  # TODO(unknown): Do a better job of finding .h files so we are confident that
+  # not having the .h file means there isn't one.
+  if filename.endswith('.cc') and not header_found:
+    return
+
+  # All the lines have been processed, report the errors found.
+  for required_header_unstripped in required:
+    template = required[required_header_unstripped][1]
+    if required_header_unstripped.strip('<>"') not in include_dict:
+      error(filename, required[required_header_unstripped][0],
+            'build/include_what_you_use', 4,
+            'Add #include ' + required_header_unstripped + ' for ' + template)
+
+
+_RE_PATTERN_EXPLICIT_MAKEPAIR = re.compile(r'\bmake_pair\s*<')
+
+
+def CheckMakePairUsesDeduction(filename, clean_lines, linenum, error):
+  """Check that make_pair's template arguments are deduced.
+
+  G++ 4.6 in C++11 mode fails badly if make_pair's template arguments are
+  specified explicitly, and such use isn't intended in any case.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    error: The function to call with any errors found.
+  """
+  line = clean_lines.elided[linenum]
+  match = _RE_PATTERN_EXPLICIT_MAKEPAIR.search(line)
+  if match:
+    error(filename, linenum, 'build/explicit_make_pair',
+          4,  # 4 = high confidence
+          'For C++11-compatibility, omit template arguments from make_pair'
+          ' OR use pair directly OR if appropriate, construct a pair directly')
+
+
+def CheckDefaultLambdaCaptures(filename, clean_lines, linenum, error):
+  """Check that default lambda captures are not used.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    error: The function to call with any errors found.
+  """
+  line = clean_lines.elided[linenum]
+
+  # A lambda introducer specifies a default capture if it starts with "[="
+  # or if it starts with "[&" _not_ followed by an identifier.
+  match = Match(r'^(.*)\[\s*(?:=|&[^\w])', line)
+  if match:
+    # Found a potential error, check what comes after the lambda-introducer.
+    # If it's not open parenthesis (for lambda-declarator) or open brace
+    # (for compound-statement), it's not a lambda.
+    line, _, pos = CloseExpression(clean_lines, linenum, len(match.group(1)))
+    if pos >= 0 and Match(r'^\s*[{(]', line[pos:]):
+      error(filename, linenum, 'build/c++11',
+            4,  # 4 = high confidence
+            'Default lambda captures are an unapproved C++ feature.')
+
+
+def CheckRedundantVirtual(filename, clean_lines, linenum, error):
+  """Check if line contains a redundant "virtual" function-specifier.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    error: The function to call with any errors found.
+  """
+  # Look for "virtual" on current line.
+  line = clean_lines.elided[linenum]
+  virtual = Match(r'^(.*)(\bvirtual\b)(.*)$', line)
+  if not virtual: return
+
+  # Ignore "virtual" keywords that are near access-specifiers.  These
+  # are only used in class base-specifier and do not apply to member
+  # functions.
+  if (Search(r'\b(public|protected|private)\s+$', virtual.group(1)) or
+      Match(r'^\s+(public|protected|private)\b', virtual.group(3))):
+    return
+
+  # Ignore the "virtual" keyword from virtual base classes.  Usually
+  # there is a column on the same line in these cases (virtual base
+  # classes are rare in google3 because multiple inheritance is rare).
+  if Match(r'^.*[^:]:[^:].*$', line): return
+
+  # Look for the next opening parenthesis.  This is the start of the
+  # parameter list (possibly on the next line shortly after virtual).
+  # TODO(unknown): doesn't work if there are virtual functions with
+  # decltype() or other things that use parentheses, but csearch suggests
+  # that this is rare.
+  end_col = -1
+  end_line = -1
+  start_col = len(virtual.group(2))
+  for start_line in xrange(linenum, min(linenum + 3, clean_lines.NumLines())):
+    line = clean_lines.elided[start_line][start_col:]
+    parameter_list = Match(r'^([^(]*)\(', line)
+    if parameter_list:
+      # Match parentheses to find the end of the parameter list
+      (_, end_line, end_col) = CloseExpression(
+          clean_lines, start_line, start_col + len(parameter_list.group(1)))
+      break
+    start_col = 0
+
+  if end_col < 0:
+    return  # Couldn't find end of parameter list, give up
+
+  # Look for "override" or "final" after the parameter list
+  # (possibly on the next few lines).
+  for i in xrange(end_line, min(end_line + 3, clean_lines.NumLines())):
+    line = clean_lines.elided[i][end_col:]
+    match = Search(r'\b(override|final)\b', line)
+    if match:
+      error(filename, linenum, 'readability/inheritance', 4,
+            ('"virtual" is redundant since function is '
+             'already declared as "%s"' % match.group(1)))
+
+    # Set end_col to check whole lines after we are done with the
+    # first line.
+    end_col = 0
+    if Search(r'[^\w]\s*$', line):
+      break
+
+
+def CheckRedundantOverrideOrFinal(filename, clean_lines, linenum, error):
+  """Check if line contains a redundant "override" or "final" virt-specifier.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    error: The function to call with any errors found.
+  """
+  # Look for closing parenthesis nearby.  We need one to confirm where
+  # the declarator ends and where the virt-specifier starts to avoid
+  # false positives.
+  line = clean_lines.elided[linenum]
+  declarator_end = line.rfind(')')
+  if declarator_end >= 0:
+    fragment = line[declarator_end:]
+  else:
+    if linenum > 1 and clean_lines.elided[linenum - 1].rfind(')') >= 0:
+      fragment = line
+    else:
+      return
+
+  # Check that at most one of "override" or "final" is present, not both
+  if Search(r'\boverride\b', fragment) and Search(r'\bfinal\b', fragment):
+    error(filename, linenum, 'readability/inheritance', 4,
+          ('"override" is redundant since function is '
+           'already declared as "final"'))
+
+
+
+
+# Returns true if we are at a new block, and it is directly
+# inside of a namespace.
+def IsBlockInNameSpace(nesting_state, is_forward_declaration):
+  """Checks that the new block is directly in a namespace.
+
+  Args:
+    nesting_state: The _NestingState object that contains info about our state.
+    is_forward_declaration: If the class is a forward declared class.
+  Returns:
+    Whether or not the new block is directly in a namespace.
+  """
+  if is_forward_declaration:
+    if len(nesting_state.stack) >= 1 and (
+        isinstance(nesting_state.stack[-1], _NamespaceInfo)):
+      return True
+    else:
+      return False
+
+  return (len(nesting_state.stack) > 1 and
+          nesting_state.stack[-1].check_namespace_indentation and
+          isinstance(nesting_state.stack[-2], _NamespaceInfo))
+
+
+def ShouldCheckNamespaceIndentation(nesting_state, is_namespace_indent_item,
+                                    raw_lines_no_comments, linenum):
+  """This method determines if we should apply our namespace indentation check.
+
+  Args:
+    nesting_state: The current nesting state.
+    is_namespace_indent_item: If we just put a new class on the stack, True.
+      If the top of the stack is not a class, or we did not recently
+      add the class, False.
+    raw_lines_no_comments: The lines without the comments.
+    linenum: The current line number we are processing.
+
+  Returns:
+    True if we should apply our namespace indentation check. Currently, it
+    only works for classes and namespaces inside of a namespace.
+  """
+
+  is_forward_declaration = IsForwardClassDeclaration(raw_lines_no_comments,
+                                                     linenum)
+
+  if not (is_namespace_indent_item or is_forward_declaration):
+    return False
+
+  # If we are in a macro, we do not want to check the namespace indentation.
+  if IsMacroDefinition(raw_lines_no_comments, linenum):
+    return False
+
+  return IsBlockInNameSpace(nesting_state, is_forward_declaration)
+
+
+# Call this method if the line is directly inside of a namespace.
+# If the line above is blank (excluding comments) or the start of
+# an inner namespace, it cannot be indented.
+def CheckItemIndentationInNamespace(filename, raw_lines_no_comments, linenum,
+                                    error):
+  line = raw_lines_no_comments[linenum]
+  if Match(r'^\s+', line):
+    error(filename, linenum, 'runtime/indentation_namespace', 4,
+          'Do not indent within a namespace')
+
+
+def ProcessLine(filename, file_extension, clean_lines, line,
+                include_state, function_state, nesting_state, error,
+                extra_check_functions=[]):
+  """Processes a single line in the file.
+
+  Args:
+    filename: Filename of the file that is being processed.
+    file_extension: The extension (dot not included) of the file.
+    clean_lines: An array of strings, each representing a line of the file,
+                 with comments stripped.
+    line: Number of line being processed.
+    include_state: An _IncludeState instance in which the headers are inserted.
+    function_state: A _FunctionState instance which counts function lines, etc.
+    nesting_state: A NestingState instance which maintains information about
+                   the current stack of nested blocks being parsed.
+    error: A callable to which errors are reported, which takes 4 arguments:
+           filename, line number, error level, and message
+    extra_check_functions: An array of additional check functions that will be
+                           run on each source line. Each function takes 4
+                           arguments: filename, clean_lines, line, error
+  """
+  raw_lines = clean_lines.raw_lines
+  ParseNolintSuppressions(filename, raw_lines[line], line, error)
+  nesting_state.Update(filename, clean_lines, line, error)
+  CheckForNamespaceIndentation(filename, nesting_state, clean_lines, line,
+                               error)
+  if nesting_state.InAsmBlock(): return
+  CheckForFunctionLengths(filename, clean_lines, line, function_state, error)
+  CheckForMultilineCommentsAndStrings(filename, clean_lines, line, error)
+  CheckStyle(filename, clean_lines, line, file_extension, nesting_state, error)
+  CheckLanguage(filename, clean_lines, line, file_extension, include_state,
+                nesting_state, error)
+  CheckForNonConstReference(filename, clean_lines, line, nesting_state, error)
+  CheckForNonStandardConstructs(filename, clean_lines, line,
+                                nesting_state, error)
+  CheckVlogArguments(filename, clean_lines, line, error)
+  CheckPosixThreading(filename, clean_lines, line, error)
+  CheckInvalidIncrement(filename, clean_lines, line, error)
+  CheckMakePairUsesDeduction(filename, clean_lines, line, error)
+  CheckDefaultLambdaCaptures(filename, clean_lines, line, error)
+  CheckRedundantVirtual(filename, clean_lines, line, error)
+  CheckRedundantOverrideOrFinal(filename, clean_lines, line, error)
+  for check_fn in extra_check_functions:
+    check_fn(filename, clean_lines, line, error)
+
+def FlagCxx11Features(filename, clean_lines, linenum, error):
+  """Flag those c++11 features that we only allow in certain places.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    error: The function to call with any errors found.
+  """
+  line = clean_lines.elided[linenum]
+
+  # Flag unapproved C++11 headers.
+  include = Match(r'\s*#\s*include\s+[<"]([^<"]+)[">]', line)
+  if include and include.group(1) in ('cfenv',
+                                      'condition_variable',
+                                      'fenv.h',
+                                      'future',
+                                      'mutex',
+                                      'thread',
+                                      'chrono',
+                                      'ratio',
+                                      'regex',
+                                      'system_error',
+                                     ):
+    error(filename, linenum, 'build/c++11', 5,
+          ('<%s> is an unapproved C++11 header.') % include.group(1))
+
+  # The only place where we need to worry about C++11 keywords and library
+  # features in preprocessor directives is in macro definitions.
+  if Match(r'\s*#', line) and not Match(r'\s*#\s*define\b', line): return
+
+  # These are classes and free functions.  The classes are always
+  # mentioned as std::*, but we only catch the free functions if
+  # they're not found by ADL.  They're alphabetical by header.
+  for top_name in (
+      # type_traits
+      'alignment_of',
+      'aligned_union',
+      ):
+    if Search(r'\bstd::%s\b' % top_name, line):
+      error(filename, linenum, 'build/c++11', 5,
+            ('std::%s is an unapproved C++11 class or function.  Send c-style '
+             'an example of where it would make your code more readable, and '
+             'they may let you use it.') % top_name)
+
+
+def ProcessFileData(filename, file_extension, lines, error,
+                    extra_check_functions=[]):
+  """Performs lint checks and reports any errors to the given error function.
+
+  Args:
+    filename: Filename of the file that is being processed.
+    file_extension: The extension (dot not included) of the file.
+    lines: An array of strings, each representing a line of the file, with the
+           last element being empty if the file is terminated with a newline.
+    error: A callable to which errors are reported, which takes 4 arguments:
+           filename, line number, error level, and message
+    extra_check_functions: An array of additional check functions that will be
+                           run on each source line. Each function takes 4
+                           arguments: filename, clean_lines, line, error
+  """
+  lines = (['// marker so line numbers and indices both start at 1'] + lines +
+           ['// marker so line numbers end in a known way'])
+
+  include_state = _IncludeState()
+  function_state = _FunctionState()
+  nesting_state = NestingState()
+
+  ResetNolintSuppressions()
+
+  CheckForCopyright(filename, lines, error)
+
+  RemoveMultiLineComments(filename, lines, error)
+  clean_lines = CleansedLines(lines)
+
+  if file_extension == 'h':
+    CheckForHeaderGuard(filename, clean_lines, error)
+
+  for line in xrange(clean_lines.NumLines()):
+    ProcessLine(filename, file_extension, clean_lines, line,
+                include_state, function_state, nesting_state, error,
+                extra_check_functions)
+    FlagCxx11Features(filename, clean_lines, line, error)
+  nesting_state.CheckCompletedBlocks(filename, error)
+
+  CheckForIncludeWhatYouUse(filename, clean_lines, include_state, error)
+  
+  # Check that the .cc file has included its header if it exists.
+  if file_extension == 'cc':
+    CheckHeaderFileIncluded(filename, include_state, error)
+
+  # We check here rather than inside ProcessLine so that we see raw
+  # lines rather than "cleaned" lines.
+  CheckForBadCharacters(filename, lines, error)
+
+  CheckForNewlineAtEOF(filename, lines, error)
+
+def ProcessConfigOverrides(filename):
+  """ Loads the configuration files and processes the config overrides.
+
+  Args:
+    filename: The name of the file being processed by the linter.
+
+  Returns:
+    False if the current |filename| should not be processed further.
+  """
+
+  abs_filename = os.path.abspath(filename)
+  cfg_filters = []
+  keep_looking = True
+  while keep_looking:
+    abs_path, base_name = os.path.split(abs_filename)
+    if not base_name:
+      break  # Reached the root directory.
+
+    cfg_file = os.path.join(abs_path, "CPPLINT.cfg")
+    abs_filename = abs_path
+    if not os.path.isfile(cfg_file):
+      continue
+
+    try:
+      with open(cfg_file) as file_handle:
+        for line in file_handle:
+          line, _, _ = line.partition('#')  # Remove comments.
+          if not line.strip():
+            continue
+
+          name, _, val = line.partition('=')
+          name = name.strip()
+          val = val.strip()
+          if name == 'set noparent':
+            keep_looking = False
+          elif name == 'filter':
+            cfg_filters.append(val)
+          elif name == 'exclude_files':
+            # When matching exclude_files pattern, use the base_name of
+            # the current file name or the directory name we are processing.
+            # For example, if we are checking for lint errors in /foo/bar/baz.cc
+            # and we found the .cfg file at /foo/CPPLINT.cfg, then the config
+            # file's "exclude_files" filter is meant to be checked against "bar"
+            # and not "baz" nor "bar/baz.cc".
+            if base_name:
+              pattern = re.compile(val)
+              if pattern.match(base_name):
+                sys.stderr.write('Ignoring "%s": file excluded by "%s". '
+                                 'File path component "%s" matches '
+                                 'pattern "%s"\n' %
+                                 (filename, cfg_file, base_name, val))
+                return False
+          elif name == 'linelength':
+            global _line_length
+            try:
+                _line_length = int(val)
+            except ValueError:
+                sys.stderr.write('Line length must be numeric.')
+          else:
+            sys.stderr.write(
+                'Invalid configuration option (%s) in file %s\n' %
+                (name, cfg_file))
+
+    except IOError:
+      sys.stderr.write(
+          "Skipping config file '%s': Can't open for reading\n" % cfg_file)
+      keep_looking = False
+
+  # Apply all the accumulated filters in reverse order (top-level directory
+  # config options having the least priority).
+  for filter in reversed(cfg_filters):
+     _AddFilters(filter)
+
+  return True
+
+
+def ProcessFile(filename, vlevel, extra_check_functions=[]):
+  """Does google-lint on a single file.
+
+  Args:
+    filename: The name of the file to parse.
+
+    vlevel: The level of errors to report.  Every error of confidence
+    >= verbose_level will be reported.  0 is a good default.
+
+    extra_check_functions: An array of additional check functions that will be
+                           run on each source line. Each function takes 4
+                           arguments: filename, clean_lines, line, error
+  """
+
+  _SetVerboseLevel(vlevel)
+  _BackupFilters()
+
+  if not ProcessConfigOverrides(filename):
+    _RestoreFilters()
+    return
+
+  lf_lines = []
+  crlf_lines = []
+  try:
+    # Support the UNIX convention of using "-" for stdin.  Note that
+    # we are not opening the file with universal newline support
+    # (which codecs doesn't support anyway), so the resulting lines do
+    # contain trailing '\r' characters if we are reading a file that
+    # has CRLF endings.
+    # If after the split a trailing '\r' is present, it is removed
+    # below.
+    if filename == '-':
+      lines = codecs.StreamReaderWriter(sys.stdin,
+                                        codecs.getreader('utf8'),
+                                        codecs.getwriter('utf8'),
+                                        'replace').read().split('\n')
+    else:
+      lines = codecs.open(filename, 'r', 'utf8', 'replace').read().split('\n')
+
+    # Remove trailing '\r'.
+    # The -1 accounts for the extra trailing blank line we get from split()
+    for linenum in range(len(lines) - 1):
+      if lines[linenum].endswith('\r'):
+        lines[linenum] = lines[linenum].rstrip('\r')
+        crlf_lines.append(linenum + 1)
+      else:
+        lf_lines.append(linenum + 1)
+
+  except IOError:
+    sys.stderr.write(
+        "Skipping input '%s': Can't open for reading\n" % filename)
+    _RestoreFilters()
+    return
+
+  # Note, if no dot is found, this will give the entire filename as the ext.
+  file_extension = filename[filename.rfind('.') + 1:]
+
+  # When reading from stdin, the extension is unknown, so no cpplint tests
+  # should rely on the extension.
+  if filename != '-' and file_extension not in _valid_extensions:
+    sys.stderr.write('Ignoring %s; not a valid file name '
+                     '(%s)\n' % (filename, ', '.join(_valid_extensions)))
+  else:
+    ProcessFileData(filename, file_extension, lines, Error,
+                    extra_check_functions)
+
+    # If end-of-line sequences are a mix of LF and CR-LF, issue
+    # warnings on the lines with CR.
+    #
+    # Don't issue any warnings if all lines are uniformly LF or CR-LF,
+    # since critique can handle these just fine, and the style guide
+    # doesn't dictate a particular end of line sequence.
+    #
+    # We can't depend on os.linesep to determine what the desired
+    # end-of-line sequence should be, since that will return the
+    # server-side end-of-line sequence.
+    if lf_lines and crlf_lines:
+      # Warn on every line with CR.  An alternative approach might be to
+      # check whether the file is mostly CRLF or just LF, and warn on the
+      # minority, we bias toward LF here since most tools prefer LF.
+      for linenum in crlf_lines:
+        Error(filename, linenum, 'whitespace/newline', 1,
+              'Unexpected \\r (^M) found; better to use only \\n')
+
+  sys.stderr.write('Done processing %s\n' % filename)
+  _RestoreFilters()
+
+
+def PrintUsage(message):
+  """Prints a brief usage string and exits, optionally with an error message.
+
+  Args:
+    message: The optional error message.
+  """
+  sys.stderr.write(_USAGE)
+  if message:
+    sys.exit('\nFATAL ERROR: ' + message)
+  else:
+    sys.exit(1)
+
+
+def PrintCategories():
+  """Prints a list of all the error-categories used by error messages.
+
+  These are the categories used to filter messages via --filter.
+  """
+  sys.stderr.write(''.join('  %s\n' % cat for cat in _ERROR_CATEGORIES))
+  sys.exit(0)
+
+
+def ParseArguments(args):
+  """Parses the command line arguments.
+
+  This may set the output format and verbosity level as side-effects.
+
+  Args:
+    args: The command line arguments:
+
+  Returns:
+    The list of filenames to lint.
+  """
+  try:
+    (opts, filenames) = getopt.getopt(args, '', ['help', 'output=', 'verbose=',
+                                                 'counting=',
+                                                 'filter=',
+                                                 'root=',
+                                                 'linelength=',
+                                                 'extensions='])
+  except getopt.GetoptError:
+    PrintUsage('Invalid arguments.')
+
+  verbosity = _VerboseLevel()
+  output_format = _OutputFormat()
+  filters = ''
+  counting_style = ''
+
+  for (opt, val) in opts:
+    if opt == '--help':
+      PrintUsage(None)
+    elif opt == '--output':
+      if val not in ('emacs', 'vs7', 'eclipse'):
+        PrintUsage('The only allowed output formats are emacs, vs7 and eclipse.')
+      output_format = val
+    elif opt == '--verbose':
+      verbosity = int(val)
+    elif opt == '--filter':
+      filters = val
+      if not filters:
+        PrintCategories()
+    elif opt == '--counting':
+      if val not in ('total', 'toplevel', 'detailed'):
+        PrintUsage('Valid counting options are total, toplevel, and detailed')
+      counting_style = val
+    elif opt == '--root':
+      global _root
+      _root = val
+    elif opt == '--linelength':
+      global _line_length
+      try:
+          _line_length = int(val)
+      except ValueError:
+          PrintUsage('Line length must be digits.')
+    elif opt == '--extensions':
+      global _valid_extensions
+      try:
+          _valid_extensions = set(val.split(','))
+      except ValueError:
+          PrintUsage('Extensions must be comma seperated list.')
+
+  if not filenames:
+    PrintUsage('No files were specified.')
+
+  _SetOutputFormat(output_format)
+  _SetVerboseLevel(verbosity)
+  _SetFilters(filters)
+  _SetCountingStyle(counting_style)
+
+  return filenames
+
+
+def main():
+  filenames = ParseArguments(sys.argv[1:])
+
+  # Change stderr to write with replacement characters so we don't die
+  # if we try to print something containing non-ASCII characters.
+  sys.stderr = codecs.StreamReaderWriter(sys.stderr,
+                                         codecs.getreader('utf8'),
+                                         codecs.getwriter('utf8'),
+                                         'replace')
+
+  _cpplint_state.ResetErrorCounts()
+  for filename in filenames:
+    ProcessFile(filename, _cpplint_state.verbose_level)
+  _cpplint_state.PrintErrorCounts()
+
+  sys.exit(_cpplint_state.error_count > 0)
+
+
+if __name__ == '__main__':
+  main()

--- a/deps/nan/include_dirs.js
+++ b/deps/nan/include_dirs.js
@@ -1,0 +1,1 @@
+console.log(require('path').relative('.', __dirname));

--- a/deps/nan/nan.h
+++ b/deps/nan/nan.h
@@ -1,0 +1,2215 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2015 NAN contributors:
+ *   - Rod Vagg <https://github.com/rvagg>
+ *   - Benjamin Byholm <https://github.com/kkoopa>
+ *   - Trevor Norris <https://github.com/trevnorris>
+ *   - Nathan Rajlich <https://github.com/TooTallNate>
+ *   - Brett Lawson <https://github.com/brett19>
+ *   - Ben Noordhuis <https://github.com/bnoordhuis>
+ *   - David Siegel <https://github.com/agnat>
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ *
+ * Version 2.1.0: current Node 4.1.2, Node 12: 0.12.7, Node 10: 0.10.40, iojs: 3.3.1
+ *
+ * See https://github.com/nodejs/nan for the latest update to this file
+ **********************************************************************************/
+
+#ifndef NAN_H_
+#define NAN_H_
+
+#include <node_version.h>
+
+#define NODE_0_10_MODULE_VERSION 11
+#define NODE_0_12_MODULE_VERSION 14
+#define ATOM_0_21_MODULE_VERSION 41
+#define IOJS_1_0_MODULE_VERSION  42
+#define IOJS_1_1_MODULE_VERSION  43
+#define IOJS_2_0_MODULE_VERSION  44
+#define IOJS_3_0_MODULE_VERSION  45
+#define NODE_4_0_MODULE_VERSION  46
+
+#ifdef _MSC_VER
+# define NAN_HAS_CPLUSPLUS_11 (_MSC_VER >= 1800)
+#else
+# define NAN_HAS_CPLUSPLUS_11 (__cplusplus >= 201103L)
+#endif
+
+#if NODE_MODULE_VERSION >= IOJS_3_0_MODULE_VERSION && ! NAN_HAS_CPLUSPLUS_11
+# error This version of node/NAN/v8 requires a C++11 compiler
+#endif
+
+#include <uv.h>
+#include <node.h>
+#include <node_buffer.h>
+#include <node_object_wrap.h>
+#include <algorithm>
+#include <cstring>
+#include <climits>
+#include <cstdlib>
+#if defined(_MSC_VER)
+# pragma warning( push )
+# pragma warning( disable : 4530 )
+# include <string>
+# include <vector>
+# pragma warning( pop )
+#else
+# include <string>
+# include <vector>
+#endif
+
+// uv helpers
+#ifdef UV_VERSION_MAJOR
+# ifndef UV_VERSION_PATCH
+#  define UV_VERSION_PATCH 0
+# endif
+# define NAUV_UVVERSION ((UV_VERSION_MAJOR << 16) | \
+                         (UV_VERSION_MINOR <<  8) | \
+                         (UV_VERSION_PATCH))
+#else
+# define NAUV_UVVERSION 0x000b00
+#endif
+
+#if NAUV_UVVERSION < 0x000b0b
+# ifdef WIN32
+#  include <windows.h>
+# else
+#  include <pthread.h>
+# endif
+#endif
+
+namespace Nan {
+
+#if defined(__GNUC__) && !(defined(DEBUG) && DEBUG)
+# define NAN_INLINE inline __attribute__((always_inline))
+#elif defined(_MSC_VER) && !(defined(DEBUG) && DEBUG)
+# define NAN_INLINE __forceinline
+#else
+# define NAN_INLINE inline
+#endif
+
+#if defined(__GNUC__) && \
+    !(defined(V8_DISABLE_DEPRECATIONS) && V8_DISABLE_DEPRECATIONS)
+# define NAN_DEPRECATED __attribute__((deprecated))
+#elif defined(_MSC_VER) && \
+    !(defined(V8_DISABLE_DEPRECATIONS) && V8_DISABLE_DEPRECATIONS)
+# define NAN_DEPRECATED __declspec(deprecated)
+#else
+# define NAN_DEPRECATED
+#endif
+
+#if __cplusplus >= 201103L
+# define NAN_DISALLOW_ASSIGN(CLASS) void operator=(const CLASS&) = delete;
+# define NAN_DISALLOW_COPY(CLASS) CLASS(const CLASS&) = delete;
+# define NAN_DISALLOW_MOVE(CLASS)                                              \
+    CLASS(CLASS&&) = delete;  /* NOLINT(build/c++11) */                        \
+    void operator=(CLASS&&) = delete;
+#else
+# define NAN_DISALLOW_ASSIGN(CLASS) void operator=(const CLASS&);
+# define NAN_DISALLOW_COPY(CLASS) CLASS(const CLASS&);
+# define NAN_DISALLOW_MOVE(CLASS)
+#endif
+
+#define NAN_DISALLOW_ASSIGN_COPY(CLASS)                                        \
+    NAN_DISALLOW_ASSIGN(CLASS)                                                 \
+    NAN_DISALLOW_COPY(CLASS)
+
+#define NAN_DISALLOW_ASSIGN_MOVE(CLASS)                                        \
+    NAN_DISALLOW_ASSIGN(CLASS)                                                 \
+    NAN_DISALLOW_MOVE(CLASS)
+
+#define NAN_DISALLOW_COPY_MOVE(CLASS)                                          \
+    NAN_DISALLOW_COPY(CLASS)                                                   \
+    NAN_DISALLOW_MOVE(CLASS)
+
+#define NAN_DISALLOW_ASSIGN_COPY_MOVE(CLASS)                                   \
+    NAN_DISALLOW_ASSIGN(CLASS)                                                 \
+    NAN_DISALLOW_COPY(CLASS)                                                   \
+    NAN_DISALLOW_MOVE(CLASS)
+
+#define TYPE_CHECK(T, S)                                                       \
+    while (false) {                                                            \
+      *(static_cast<T *volatile *>(0)) = static_cast<S*>(0);                   \
+    }
+
+//=== RegistrationFunction =====================================================
+
+#if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
+  typedef v8::Handle<v8::Object> ADDON_REGISTER_FUNCTION_ARGS_TYPE;
+#else
+  typedef v8::Local<v8::Object> ADDON_REGISTER_FUNCTION_ARGS_TYPE;
+#endif
+
+#define NAN_MODULE_INIT(name)                                                  \
+    void name(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target)
+
+//=== CallbackInfo =============================================================
+
+#include "nan_callbacks.h"  // NOLINT(build/include)
+
+//==============================================================================
+
+#if (NODE_MODULE_VERSION < NODE_0_12_MODULE_VERSION)
+typedef v8::Script             UnboundScript;
+typedef v8::Script             BoundScript;
+#else
+typedef v8::UnboundScript      UnboundScript;
+typedef v8::Script             BoundScript;
+#endif
+
+#if (NODE_MODULE_VERSION < ATOM_0_21_MODULE_VERSION)
+typedef v8::String::ExternalAsciiStringResource
+    ExternalOneByteStringResource;
+#else
+typedef v8::String::ExternalOneByteStringResource
+    ExternalOneByteStringResource;
+#endif
+
+#if (NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION)
+template<typename T>
+class NonCopyablePersistentTraits :
+    public v8::NonCopyablePersistentTraits<T> {};
+template<typename T>
+class CopyablePersistentTraits :
+    public v8::CopyablePersistentTraits<T> {};
+
+template<typename T>
+class PersistentBase :
+    public v8::PersistentBase<T> {};
+
+template<typename T, typename M = v8::NonCopyablePersistentTraits<T> >
+class Persistent;
+#else
+template<typename T> class NonCopyablePersistentTraits;
+template<typename T> class PersistentBase;
+template<typename T, typename P> class WeakCallbackData;
+template<typename T, typename M = NonCopyablePersistentTraits<T> >
+class Persistent;
+#endif  // NODE_MODULE_VERSION
+
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
+  (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
+# include "nan_maybe_43_inl.h"  // NOLINT(build/include)
+#else
+# include "nan_maybe_pre_43_inl.h"  // NOLINT(build/include)
+#endif
+
+#include "nan_converters.h"  // NOLINT(build/include)
+#include "nan_new.h"  // NOLINT(build/include)
+
+#if NAUV_UVVERSION < 0x000b17
+#define NAUV_WORK_CB(func) \
+    void func(uv_async_t *async, int)
+#else
+#define NAUV_WORK_CB(func) \
+    void func(uv_async_t *async)
+#endif
+
+#if NAUV_UVVERSION >= 0x000b0b
+
+typedef uv_key_t nauv_key_t;
+
+inline int nauv_key_create(nauv_key_t *key) {
+  return uv_key_create(key);
+}
+
+inline void nauv_key_delete(nauv_key_t *key) {
+  uv_key_delete(key);
+}
+
+inline void* nauv_key_get(nauv_key_t *key) {
+  return uv_key_get(key);
+}
+
+inline void nauv_key_set(nauv_key_t *key, void *value) {
+  uv_key_set(key, value);
+}
+
+#else
+
+/* Implement thread local storage for older versions of libuv.
+ * This is essentially a backport of libuv commit 5d2434bf
+ * written by Ben Noordhuis, adjusted for names and inline.
+ */
+
+#ifndef WIN32
+
+typedef pthread_key_t nauv_key_t;
+
+inline int nauv_key_create(nauv_key_t* key) {
+  return -pthread_key_create(key, NULL);
+}
+
+inline void nauv_key_delete(nauv_key_t* key) {
+  if (pthread_key_delete(*key))
+    abort();
+}
+
+inline void* nauv_key_get(nauv_key_t* key) {
+  return pthread_getspecific(*key);
+}
+
+inline void nauv_key_set(nauv_key_t* key, void* value) {
+  if (pthread_setspecific(*key, value))
+    abort();
+}
+
+#else
+
+typedef struct {
+  DWORD tls_index;
+} nauv_key_t;
+
+inline int nauv_key_create(nauv_key_t* key) {
+  key->tls_index = TlsAlloc();
+  if (key->tls_index == TLS_OUT_OF_INDEXES)
+    return UV_ENOMEM;
+  return 0;
+}
+
+inline void nauv_key_delete(nauv_key_t* key) {
+  if (TlsFree(key->tls_index) == FALSE)
+    abort();
+  key->tls_index = TLS_OUT_OF_INDEXES;
+}
+
+inline void* nauv_key_get(nauv_key_t* key) {
+  void* value = TlsGetValue(key->tls_index);
+  if (value == NULL)
+    if (GetLastError() != ERROR_SUCCESS)
+      abort();
+  return value;
+}
+
+inline void nauv_key_set(nauv_key_t* key, void* value) {
+  if (TlsSetValue(key->tls_index, value) == FALSE)
+    abort();
+}
+
+#endif
+#endif
+
+#if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
+template<typename T>
+v8::Local<T> New(v8::Handle<T>);
+#endif
+
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
+  (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
+  typedef v8::WeakCallbackType WeakCallbackType;
+#else
+struct WeakCallbackType {
+  enum E {kParameter, kInternalFields};
+  E type;
+  WeakCallbackType(E other) : type(other) {}  // NOLINT(runtime/explicit)
+  inline bool operator==(E other) { return other == this->type; }
+  inline bool operator!=(E other) { return !operator==(other); }
+};
+#endif
+
+template<typename P> class WeakCallbackInfo;
+
+#if NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION
+# include "nan_persistent_12_inl.h"  // NOLINT(build/include)
+#else
+# include "nan_persistent_pre_12_inl.h"  // NOLINT(build/include)
+#endif
+
+namespace imp {
+  static const size_t kMaxLength = 0x3fffffff;
+  // v8::String::REPLACE_INVALID_UTF8 was introduced
+  // in node.js v0.10.29 and v0.8.27.
+#if NODE_MAJOR_VERSION > 0 || \
+    NODE_MINOR_VERSION > 10 || \
+    NODE_MINOR_VERSION == 10 && NODE_PATCH_VERSION >= 29 || \
+    NODE_MINOR_VERSION == 8 && NODE_PATCH_VERSION >= 27
+  static const unsigned kReplaceInvalidUtf8 = v8::String::REPLACE_INVALID_UTF8;
+#else
+  static const unsigned kReplaceInvalidUtf8 = 0;
+#endif
+}  // end of namespace imp
+
+//=== HandleScope ==============================================================
+
+class HandleScope {
+  v8::HandleScope scope;
+
+ public:
+#if NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION
+  inline HandleScope() : scope(v8::Isolate::GetCurrent()) {}
+  inline static int NumberOfHandles() {
+    return v8::HandleScope::NumberOfHandles(v8::Isolate::GetCurrent());
+  }
+#else
+  inline HandleScope() : scope() {}
+  inline static int NumberOfHandles() {
+    return v8::HandleScope::NumberOfHandles();
+  }
+#endif
+
+ private:
+  // Make it hard to create heap-allocated or illegal handle scopes by
+  // disallowing certain operations.
+  HandleScope(const HandleScope &);
+  void operator=(const HandleScope &);
+  void *operator new(size_t size);
+  void operator delete(void *, size_t);
+};
+
+class EscapableHandleScope {
+ public:
+#if NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION
+  inline EscapableHandleScope() : scope(v8::Isolate::GetCurrent()) {}
+
+  inline static int NumberOfHandles() {
+    return v8::EscapableHandleScope::NumberOfHandles(v8::Isolate::GetCurrent());
+  }
+
+  template<typename T>
+  inline v8::Local<T> Escape(v8::Local<T> value) {
+    return scope.Escape(value);
+  }
+
+ private:
+  v8::EscapableHandleScope scope;
+#else
+  inline EscapableHandleScope() : scope() {}
+
+  inline static int NumberOfHandles() {
+    return v8::HandleScope::NumberOfHandles();
+  }
+
+  template<typename T>
+  inline v8::Local<T> Escape(v8::Local<T> value) {
+    return scope.Close(value);
+  }
+
+ private:
+  v8::HandleScope scope;
+#endif
+
+ private:
+  // Make it hard to create heap-allocated or illegal handle scopes by
+  // disallowing certain operations.
+  EscapableHandleScope(const EscapableHandleScope &);
+  void operator=(const EscapableHandleScope &);
+  void *operator new(size_t size);
+  void operator delete(void *, size_t);
+};
+
+//=== TryCatch =================================================================
+
+class TryCatch {
+  v8::TryCatch try_catch_;
+  friend void FatalException(const TryCatch&);
+
+ public:
+#if NODE_MODULE_VERSION > NODE_0_12_MODULE_VERSION
+  TryCatch() : try_catch_(v8::Isolate::GetCurrent()) {}
+#endif
+
+  NAN_INLINE bool HasCaught() const { return try_catch_.HasCaught(); }
+
+  NAN_INLINE bool CanContinue() const { return try_catch_.CanContinue(); }
+
+  NAN_INLINE v8::Local<v8::Value> ReThrow() {
+#if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
+    return New(try_catch_.ReThrow());
+#else
+    return try_catch_.ReThrow();
+#endif
+  }
+
+  NAN_INLINE v8::Local<v8::Value> Exception() const {
+    return try_catch_.Exception();
+  }
+
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
+  (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
+  NAN_INLINE v8::MaybeLocal<v8::Value> StackTrace() const {
+    return try_catch_.StackTrace(GetCurrentContext());
+  }
+#else
+  NAN_INLINE MaybeLocal<v8::Value> StackTrace() const {
+    return MaybeLocal<v8::Value>(try_catch_.StackTrace());
+  }
+#endif
+
+  NAN_INLINE v8::Local<v8::Message> Message() const {
+    return try_catch_.Message();
+  }
+
+  NAN_INLINE void Reset() { try_catch_.Reset(); }
+
+  NAN_INLINE void SetVerbose(bool value) { try_catch_.SetVerbose(value); }
+
+  NAN_INLINE void SetCaptureMessage(bool value) {
+    try_catch_.SetCaptureMessage(value);
+  }
+};
+
+//============ =================================================================
+
+/* node 0.12  */
+#if NODE_MODULE_VERSION >= NODE_0_12_MODULE_VERSION
+  NAN_INLINE
+  void SetCounterFunction(v8::CounterLookupCallback cb) {
+    v8::Isolate::GetCurrent()->SetCounterFunction(cb);
+  }
+
+  NAN_INLINE
+  void SetCreateHistogramFunction(v8::CreateHistogramCallback cb) {
+    v8::Isolate::GetCurrent()->SetCreateHistogramFunction(cb);
+  }
+
+  NAN_INLINE
+  void SetAddHistogramSampleFunction(v8::AddHistogramSampleCallback cb) {
+    v8::Isolate::GetCurrent()->SetAddHistogramSampleFunction(cb);
+  }
+
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
+  (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
+  NAN_INLINE bool IdleNotification(int idle_time_in_ms) {
+    return v8::Isolate::GetCurrent()->IdleNotificationDeadline(
+        idle_time_in_ms * 0.001);
+  }
+# else
+  NAN_INLINE bool IdleNotification(int idle_time_in_ms) {
+    return v8::Isolate::GetCurrent()->IdleNotification(idle_time_in_ms);
+  }
+#endif
+
+  NAN_INLINE void LowMemoryNotification() {
+    v8::Isolate::GetCurrent()->LowMemoryNotification();
+  }
+
+  NAN_INLINE void ContextDisposedNotification() {
+    v8::Isolate::GetCurrent()->ContextDisposedNotification();
+  }
+#else
+  NAN_INLINE
+  void SetCounterFunction(v8::CounterLookupCallback cb) {
+    v8::V8::SetCounterFunction(cb);
+  }
+
+  NAN_INLINE
+  void SetCreateHistogramFunction(v8::CreateHistogramCallback cb) {
+    v8::V8::SetCreateHistogramFunction(cb);
+  }
+
+  NAN_INLINE
+  void SetAddHistogramSampleFunction(v8::AddHistogramSampleCallback cb) {
+    v8::V8::SetAddHistogramSampleFunction(cb);
+  }
+
+  NAN_INLINE bool IdleNotification(int idle_time_in_ms) {
+    return v8::V8::IdleNotification(idle_time_in_ms);
+  }
+
+  NAN_INLINE void LowMemoryNotification() {
+    v8::V8::LowMemoryNotification();
+  }
+
+  NAN_INLINE void ContextDisposedNotification() {
+    v8::V8::ContextDisposedNotification();
+  }
+#endif
+
+#if (NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION)  // Node 0.12
+  NAN_INLINE v8::Local<v8::Primitive> Undefined() {
+# if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
+    EscapableHandleScope scope;
+    return scope.Escape(New(v8::Undefined(v8::Isolate::GetCurrent())));
+# else
+    return v8::Undefined(v8::Isolate::GetCurrent());
+# endif
+  }
+
+  NAN_INLINE v8::Local<v8::Primitive> Null() {
+# if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
+    EscapableHandleScope scope;
+    return scope.Escape(New(v8::Null(v8::Isolate::GetCurrent())));
+# else
+    return v8::Null(v8::Isolate::GetCurrent());
+# endif
+  }
+
+  NAN_INLINE v8::Local<v8::Boolean> True() {
+# if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
+    EscapableHandleScope scope;
+    return scope.Escape(New(v8::True(v8::Isolate::GetCurrent())));
+# else
+    return v8::True(v8::Isolate::GetCurrent());
+# endif
+  }
+
+  NAN_INLINE v8::Local<v8::Boolean> False() {
+# if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
+    EscapableHandleScope scope;
+    return scope.Escape(New(v8::False(v8::Isolate::GetCurrent())));
+# else
+    return v8::False(v8::Isolate::GetCurrent());
+# endif
+  }
+
+  NAN_INLINE v8::Local<v8::String> EmptyString() {
+    return v8::String::Empty(v8::Isolate::GetCurrent());
+  }
+
+  NAN_INLINE int AdjustExternalMemory(int bc) {
+    return static_cast<int>(
+        v8::Isolate::GetCurrent()->AdjustAmountOfExternalAllocatedMemory(bc));
+  }
+
+  NAN_INLINE void SetTemplate(
+      v8::Local<v8::Template> templ
+    , const char *name
+    , v8::Local<v8::Data> value) {
+    templ->Set(v8::Isolate::GetCurrent(), name, value);
+  }
+
+  NAN_INLINE void SetTemplate(
+      v8::Local<v8::Template> templ
+    , v8::Local<v8::String> name
+    , v8::Local<v8::Data> value
+    , v8::PropertyAttribute attributes) {
+    templ->Set(name, value, attributes);
+  }
+
+  NAN_INLINE v8::Local<v8::Context> GetCurrentContext() {
+    return v8::Isolate::GetCurrent()->GetCurrentContext();
+  }
+
+  NAN_INLINE void* GetInternalFieldPointer(
+      v8::Local<v8::Object> object
+    , int index) {
+    return object->GetAlignedPointerFromInternalField(index);
+  }
+
+  NAN_INLINE void SetInternalFieldPointer(
+      v8::Local<v8::Object> object
+    , int index
+    , void* value) {
+    object->SetAlignedPointerInInternalField(index, value);
+  }
+
+# define NAN_GC_CALLBACK(name)                                                 \
+    void name(v8::Isolate *isolate, v8::GCType type, v8::GCCallbackFlags flags)
+
+  NAN_INLINE void GetHeapStatistics(
+      v8::HeapStatistics *heap_statistics) {
+    v8::Isolate::GetCurrent()->GetHeapStatistics(heap_statistics);
+  }
+
+# define X(NAME)                                                               \
+    NAN_INLINE v8::Local<v8::Value> NAME(const char *msg) {                    \
+      EscapableHandleScope scope;                                              \
+      return scope.Escape(v8::Exception::NAME(New(msg).ToLocalChecked()));     \
+    }                                                                          \
+                                                                               \
+    NAN_INLINE                                                                 \
+    v8::Local<v8::Value> NAME(v8::Local<v8::String> msg) {                     \
+      return v8::Exception::NAME(msg);                                         \
+    }                                                                          \
+                                                                               \
+    NAN_INLINE void Throw ## NAME(const char *msg) {                           \
+      HandleScope scope;                                                       \
+      v8::Isolate::GetCurrent()->ThrowException(                               \
+          v8::Exception::NAME(New(msg).ToLocalChecked()));                     \
+    }                                                                          \
+                                                                               \
+    NAN_INLINE void Throw ## NAME(v8::Local<v8::String> msg) {                 \
+      HandleScope scope;                                                       \
+      v8::Isolate::GetCurrent()->ThrowException(                               \
+          v8::Exception::NAME(msg));                                           \
+    }
+
+  X(Error)
+  X(RangeError)
+  X(ReferenceError)
+  X(SyntaxError)
+  X(TypeError)
+
+# undef X
+
+  NAN_INLINE void ThrowError(v8::Local<v8::Value> error) {
+    v8::Isolate::GetCurrent()->ThrowException(error);
+  }
+
+  NAN_INLINE MaybeLocal<v8::Object> NewBuffer(
+      char *data
+    , size_t length
+#if NODE_MODULE_VERSION > IOJS_2_0_MODULE_VERSION
+    , node::Buffer::FreeCallback callback
+#else
+    , node::smalloc::FreeCallback callback
+#endif
+    , void *hint
+  ) {
+    // arbitrary buffer lengths requires
+    // NODE_MODULE_VERSION >= IOJS_3_0_MODULE_VERSION
+    assert(length <= imp::kMaxLength && "too large buffer");
+#if NODE_MODULE_VERSION > IOJS_2_0_MODULE_VERSION
+    return node::Buffer::New(
+        v8::Isolate::GetCurrent(), data, length, callback, hint);
+#else
+    return MaybeLocal<v8::Object>(node::Buffer::New(
+        v8::Isolate::GetCurrent(), data, length, callback, hint));
+#endif
+  }
+
+  NAN_INLINE MaybeLocal<v8::Object> CopyBuffer(
+      const char *data
+    , uint32_t size
+  ) {
+    // arbitrary buffer lengths requires
+    // NODE_MODULE_VERSION >= IOJS_3_0_MODULE_VERSION
+    assert(size <= imp::kMaxLength && "too large buffer");
+#if NODE_MODULE_VERSION > IOJS_2_0_MODULE_VERSION
+    return node::Buffer::Copy(
+        v8::Isolate::GetCurrent(), data, size);
+#else
+    return MaybeLocal<v8::Object>(node::Buffer::New(
+        v8::Isolate::GetCurrent(), data, size));
+#endif
+  }
+
+  NAN_INLINE MaybeLocal<v8::Object> NewBuffer(uint32_t size) {
+    // arbitrary buffer lengths requires
+    // NODE_MODULE_VERSION >= IOJS_3_0_MODULE_VERSION
+    assert(size <= imp::kMaxLength && "too large buffer");
+#if NODE_MODULE_VERSION > IOJS_2_0_MODULE_VERSION
+    return node::Buffer::New(
+        v8::Isolate::GetCurrent(), size);
+#else
+    return MaybeLocal<v8::Object>(node::Buffer::New(
+        v8::Isolate::GetCurrent(), size));
+#endif
+  }
+
+  NAN_INLINE MaybeLocal<v8::Object> NewBuffer(
+      char* data
+    , uint32_t size
+  ) {
+    // arbitrary buffer lengths requires
+    // NODE_MODULE_VERSION >= IOJS_3_0_MODULE_VERSION
+    assert(size <= imp::kMaxLength && "too large buffer");
+#if NODE_MODULE_VERSION > IOJS_2_0_MODULE_VERSION
+    return node::Buffer::New(v8::Isolate::GetCurrent(), data, size);
+#else
+    return MaybeLocal<v8::Object>(
+        node::Buffer::Use(v8::Isolate::GetCurrent(), data, size));
+#endif
+  }
+
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
+  (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
+  NAN_INLINE MaybeLocal<v8::String>
+  NewOneByteString(const uint8_t * value, int length = -1) {
+    return v8::String::NewFromOneByte(v8::Isolate::GetCurrent(), value,
+          v8::NewStringType::kNormal, length);
+  }
+
+  NAN_INLINE MaybeLocal<BoundScript> CompileScript(
+      v8::Local<v8::String> s
+    , const v8::ScriptOrigin& origin
+  ) {
+    v8::ScriptCompiler::Source source(s, origin);
+    return v8::ScriptCompiler::Compile(GetCurrentContext(), &source);
+  }
+
+  NAN_INLINE MaybeLocal<BoundScript> CompileScript(
+      v8::Local<v8::String> s
+  ) {
+    v8::ScriptCompiler::Source source(s);
+    return v8::ScriptCompiler::Compile(GetCurrentContext(), &source);
+  }
+
+  NAN_INLINE MaybeLocal<v8::Value> RunScript(
+      v8::Local<UnboundScript> script
+  ) {
+    return script->BindToCurrentContext()->Run(GetCurrentContext());
+  }
+
+  NAN_INLINE MaybeLocal<v8::Value> RunScript(
+      v8::Local<BoundScript> script
+  ) {
+    return script->Run(GetCurrentContext());
+  }
+#else
+  NAN_INLINE MaybeLocal<v8::String>
+  NewOneByteString(const uint8_t * value, int length = -1) {
+    return MaybeLocal<v8::String>(
+        v8::String::NewFromOneByte(
+            v8::Isolate::GetCurrent()
+          , value
+          , v8::String::kNormalString, length));
+  }
+
+  NAN_INLINE MaybeLocal<BoundScript> CompileScript(
+      v8::Local<v8::String> s
+    , const v8::ScriptOrigin& origin
+  ) {
+    v8::ScriptCompiler::Source source(s, origin);
+    return MaybeLocal<BoundScript>(
+        v8::ScriptCompiler::Compile(v8::Isolate::GetCurrent(), &source));
+  }
+
+  NAN_INLINE MaybeLocal<BoundScript> CompileScript(
+      v8::Local<v8::String> s
+  ) {
+    v8::ScriptCompiler::Source source(s);
+    return MaybeLocal<BoundScript>(
+        v8::ScriptCompiler::Compile(v8::Isolate::GetCurrent(), &source));
+  }
+
+  NAN_INLINE MaybeLocal<v8::Value> RunScript(
+      v8::Local<UnboundScript> script
+  ) {
+    return MaybeLocal<v8::Value>(script->BindToCurrentContext()->Run());
+  }
+
+  NAN_INLINE MaybeLocal<v8::Value> RunScript(
+      v8::Local<BoundScript> script
+  ) {
+    return MaybeLocal<v8::Value>(script->Run());
+  }
+#endif
+
+  NAN_INLINE v8::Local<v8::Value> MakeCallback(
+      v8::Local<v8::Object> target
+    , v8::Local<v8::Function> func
+    , int argc
+    , v8::Local<v8::Value>* argv) {
+#if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
+    return New(node::MakeCallback(
+        v8::Isolate::GetCurrent(), target, func, argc, argv));
+#else
+    return node::MakeCallback(
+        v8::Isolate::GetCurrent(), target, func, argc, argv);
+#endif
+  }
+
+  NAN_INLINE v8::Local<v8::Value> MakeCallback(
+      v8::Local<v8::Object> target
+    , v8::Local<v8::String> symbol
+    , int argc
+    , v8::Local<v8::Value>* argv) {
+#if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
+    return New(node::MakeCallback(
+        v8::Isolate::GetCurrent(), target, symbol, argc, argv));
+#else
+    return node::MakeCallback(
+        v8::Isolate::GetCurrent(), target, symbol, argc, argv);
+#endif
+  }
+
+  NAN_INLINE v8::Local<v8::Value> MakeCallback(
+      v8::Local<v8::Object> target
+    , const char* method
+    , int argc
+    , v8::Local<v8::Value>* argv) {
+#if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
+    return New(node::MakeCallback(
+        v8::Isolate::GetCurrent(), target, method, argc, argv));
+#else
+    return node::MakeCallback(
+        v8::Isolate::GetCurrent(), target, method, argc, argv);
+#endif
+  }
+
+  NAN_INLINE void FatalException(const TryCatch& try_catch) {
+    node::FatalException(v8::Isolate::GetCurrent(), try_catch.try_catch_);
+  }
+
+  NAN_INLINE v8::Local<v8::Value> ErrnoException(
+          int errorno
+       ,  const char* syscall = NULL
+       ,  const char* message = NULL
+       ,  const char* path = NULL) {
+    return node::ErrnoException(v8::Isolate::GetCurrent(), errorno, syscall,
+            message, path);
+  }
+
+  NAN_DEPRECATED NAN_INLINE v8::Local<v8::Value> NanErrnoException(
+          int errorno
+       ,  const char* syscall = NULL
+       ,  const char* message = NULL
+       ,  const char* path = NULL) {
+    return ErrnoException(errorno, syscall, message, path);
+  }
+
+  template<typename T>
+  NAN_INLINE void SetIsolateData(
+      v8::Isolate *isolate
+    , T *data
+  ) {
+      isolate->SetData(0, data);
+  }
+
+  template<typename T>
+  NAN_INLINE T *GetIsolateData(
+      v8::Isolate *isolate
+  ) {
+      return static_cast<T*>(isolate->GetData(0));
+  }
+
+class Utf8String {
+ public:
+  NAN_INLINE explicit Utf8String(v8::Local<v8::Value> from) :
+      length_(0), str_(str_st_) {
+    if (!from.IsEmpty()) {
+      v8::Local<v8::String> string = from->ToString();
+      if (!string.IsEmpty()) {
+        size_t len = 3 * string->Length() + 1;
+        assert(len <= INT_MAX);
+        if (len > sizeof (str_st_)) {
+          str_ = static_cast<char*>(malloc(len));
+          assert(str_ != 0);
+        }
+        const int flags =
+            v8::String::NO_NULL_TERMINATION | imp::kReplaceInvalidUtf8;
+        length_ = string->WriteUtf8(str_, static_cast<int>(len), 0, flags);
+        str_[length_] = '\0';
+      }
+    }
+  }
+
+  NAN_INLINE int length() const {
+    return length_;
+  }
+
+  NAN_INLINE char* operator*() { return str_; }
+  NAN_INLINE const char* operator*() const { return str_; }
+
+  NAN_INLINE ~Utf8String() {
+    if (str_ != str_st_) {
+      free(str_);
+    }
+  }
+
+ private:
+  NAN_DISALLOW_ASSIGN_COPY_MOVE(Utf8String)
+
+  int length_;
+  char *str_;
+  char str_st_[1024];
+};
+
+#else  // Node 0.8 and 0.10
+  NAN_INLINE v8::Local<v8::Primitive> Undefined() {
+    EscapableHandleScope scope;
+    return scope.Escape(New(v8::Undefined()));
+  }
+
+  NAN_INLINE v8::Local<v8::Primitive> Null() {
+    EscapableHandleScope scope;
+    return scope.Escape(New(v8::Null()));
+  }
+
+  NAN_INLINE v8::Local<v8::Boolean> True() {
+    EscapableHandleScope scope;
+    return scope.Escape(New(v8::True()));
+  }
+
+  NAN_INLINE v8::Local<v8::Boolean> False() {
+    EscapableHandleScope scope;
+    return scope.Escape(New(v8::False()));
+  }
+
+  NAN_INLINE v8::Local<v8::String> EmptyString() {
+    return v8::String::Empty();
+  }
+
+  NAN_INLINE int AdjustExternalMemory(int bc) {
+    return static_cast<int>(v8::V8::AdjustAmountOfExternalAllocatedMemory(bc));
+  }
+
+  NAN_INLINE void SetTemplate(
+      v8::Local<v8::Template> templ
+    , const char *name
+    , v8::Local<v8::Data> value) {
+    templ->Set(name, value);
+  }
+
+  NAN_INLINE void SetTemplate(
+      v8::Local<v8::Template> templ
+    , v8::Local<v8::String> name
+    , v8::Local<v8::Data> value
+    , v8::PropertyAttribute attributes) {
+    templ->Set(name, value, attributes);
+  }
+
+  NAN_INLINE v8::Local<v8::Context> GetCurrentContext() {
+    return v8::Context::GetCurrent();
+  }
+
+  NAN_INLINE void* GetInternalFieldPointer(
+      v8::Local<v8::Object> object
+    , int index) {
+    return object->GetPointerFromInternalField(index);
+  }
+
+  NAN_INLINE void SetInternalFieldPointer(
+      v8::Local<v8::Object> object
+    , int index
+    , void* value) {
+    object->SetPointerInInternalField(index, value);
+  }
+
+# define NAN_GC_CALLBACK(name)                                                 \
+    void name(v8::GCType type, v8::GCCallbackFlags flags)
+
+  NAN_INLINE void AddGCEpilogueCallback(
+    v8::GCEpilogueCallback callback
+  , v8::GCType gc_type_filter = v8::kGCTypeAll) {
+    v8::V8::AddGCEpilogueCallback(callback, gc_type_filter);
+  }
+  NAN_INLINE void RemoveGCEpilogueCallback(
+    v8::GCEpilogueCallback callback) {
+    v8::V8::RemoveGCEpilogueCallback(callback);
+  }
+  NAN_INLINE void AddGCPrologueCallback(
+    v8::GCPrologueCallback callback
+  , v8::GCType gc_type_filter = v8::kGCTypeAll) {
+    v8::V8::AddGCPrologueCallback(callback, gc_type_filter);
+  }
+  NAN_INLINE void RemoveGCPrologueCallback(
+    v8::GCPrologueCallback callback) {
+    v8::V8::RemoveGCPrologueCallback(callback);
+  }
+  NAN_INLINE void GetHeapStatistics(
+    v8::HeapStatistics *heap_statistics) {
+    v8::V8::GetHeapStatistics(heap_statistics);
+  }
+
+# define X(NAME)                                                               \
+    NAN_INLINE v8::Local<v8::Value> NAME(const char *msg) {                    \
+      EscapableHandleScope scope;                                              \
+      return scope.Escape(v8::Exception::NAME(New(msg).ToLocalChecked()));     \
+    }                                                                          \
+                                                                               \
+    NAN_INLINE                                                                 \
+    v8::Local<v8::Value> NAME(v8::Local<v8::String> msg) {                     \
+      return v8::Exception::NAME(msg);                                         \
+    }                                                                          \
+                                                                               \
+    NAN_INLINE void Throw ## NAME(const char *msg) {                           \
+      HandleScope scope;                                                       \
+      v8::ThrowException(v8::Exception::NAME(New(msg).ToLocalChecked()));      \
+    }                                                                          \
+                                                                               \
+    NAN_INLINE                                                                 \
+    void Throw ## NAME(v8::Local<v8::String> errmsg) {                         \
+      v8::ThrowException(v8::Exception::NAME(errmsg));                         \
+    }
+
+  X(Error)
+  X(RangeError)
+  X(ReferenceError)
+  X(SyntaxError)
+  X(TypeError)
+
+# undef X
+
+  NAN_INLINE void ThrowError(v8::Local<v8::Value> error) {
+    v8::ThrowException(error);
+  }
+
+  NAN_INLINE MaybeLocal<v8::Object> NewBuffer(
+      char *data
+    , size_t length
+    , node::Buffer::free_callback callback
+    , void *hint
+  ) {
+    EscapableHandleScope scope;
+    // arbitrary buffer lengths requires
+    // NODE_MODULE_VERSION >= IOJS_3_0_MODULE_VERSION
+    assert(length <= imp::kMaxLength && "too large buffer");
+    return MaybeLocal<v8::Object>(
+        scope.Escape(New(node::Buffer::New(data, length, callback, hint)->handle_)));
+  }
+
+  NAN_INLINE MaybeLocal<v8::Object> CopyBuffer(
+      const char *data
+    , uint32_t size
+  ) {
+    EscapableHandleScope scope;
+    // arbitrary buffer lengths requires
+    // NODE_MODULE_VERSION >= IOJS_3_0_MODULE_VERSION
+    assert(size <= imp::kMaxLength && "too large buffer");
+#if NODE_MODULE_VERSION >= NODE_0_10_MODULE_VERSION
+    return MaybeLocal<v8::Object>(
+        scope.Escape(New(node::Buffer::New(data, size)->handle_)));
+#else
+    return MaybeLocal<v8::Object>(scope.Escape(
+        New(node::Buffer::New(const_cast<char*>(data), size)->handle_)));
+#endif
+  }
+
+  NAN_INLINE MaybeLocal<v8::Object> NewBuffer(uint32_t size) {
+    // arbitrary buffer lengths requires
+    // NODE_MODULE_VERSION >= IOJS_3_0_MODULE_VERSION
+    EscapableHandleScope scope;
+    assert(size <= imp::kMaxLength && "too large buffer");
+    return MaybeLocal<v8::Object>(
+        scope.Escape(New(node::Buffer::New(size)->handle_)));
+  }
+
+  NAN_INLINE void FreeData(char *data, void *hint) {
+    (void) hint;  // unused
+    delete[] data;
+  }
+
+  NAN_INLINE MaybeLocal<v8::Object> NewBuffer(
+      char* data
+    , uint32_t size
+  ) {
+    EscapableHandleScope scope;
+    // arbitrary buffer lengths requires
+    // NODE_MODULE_VERSION >= IOJS_3_0_MODULE_VERSION
+    assert(size <= imp::kMaxLength && "too large buffer");
+    return MaybeLocal<v8::Object>(scope.Escape(New(
+        node::Buffer::New(data, size, FreeData, NULL)->handle_)));
+  }
+
+namespace imp {
+NAN_INLINE void
+widenString(std::vector<uint16_t> *ws, const uint8_t *s, int l) {
+  size_t len = static_cast<size_t>(l);
+  if (l < 0) {
+    len = strlen(reinterpret_cast<const char*>(s));
+  }
+  assert(len <= INT_MAX && "string too long");
+  ws->resize(len);
+  std::copy(s, s + len, ws->begin());  // NOLINT(build/include_what_you_use)
+}
+}  // end of namespace imp
+
+  NAN_INLINE MaybeLocal<v8::String>
+  NewOneByteString(const uint8_t * value, int length = -1) {
+    std::vector<uint16_t> wideString;  // NOLINT(build/include_what_you_use)
+    imp::widenString(&wideString, value, length);
+    return imp::Factory<v8::String>::return_t(v8::String::New(
+        &wideString.front(), static_cast<int>(wideString.size())));
+  }
+
+  NAN_INLINE MaybeLocal<BoundScript> CompileScript(
+      v8::Local<v8::String> s
+    , const v8::ScriptOrigin& origin
+  ) {
+    return MaybeLocal<BoundScript>(
+        v8::Script::Compile(s, const_cast<v8::ScriptOrigin *>(&origin)));
+  }
+
+  NAN_INLINE MaybeLocal<BoundScript> CompileScript(
+    v8::Local<v8::String> s
+  ) {
+    return MaybeLocal<BoundScript>(v8::Script::Compile(s));
+  }
+
+  NAN_INLINE
+  MaybeLocal<v8::Value> RunScript(v8::Local<v8::Script> script) {
+    return MaybeLocal<v8::Value>(script->Run());
+  }
+
+  NAN_INLINE v8::Local<v8::Value> MakeCallback(
+      v8::Local<v8::Object> target
+    , v8::Local<v8::Function> func
+    , int argc
+    , v8::Local<v8::Value>* argv) {
+    return New(node::MakeCallback(target, func, argc, argv));
+  }
+
+  NAN_INLINE v8::Local<v8::Value> MakeCallback(
+      v8::Local<v8::Object> target
+    , v8::Local<v8::String> symbol
+    , int argc
+    , v8::Local<v8::Value>* argv) {
+    return New(node::MakeCallback(target, symbol, argc, argv));
+  }
+
+  NAN_INLINE v8::Local<v8::Value> MakeCallback(
+      v8::Local<v8::Object> target
+    , const char* method
+    , int argc
+    , v8::Local<v8::Value>* argv) {
+    return New(node::MakeCallback(target, method, argc, argv));
+  }
+
+  NAN_INLINE void FatalException(const TryCatch& try_catch) {
+    node::FatalException(const_cast<v8::TryCatch &>(try_catch.try_catch_));
+  }
+
+  NAN_INLINE v8::Local<v8::Value> ErrnoException(
+          int errorno
+       ,  const char* syscall = NULL
+       ,  const char* message = NULL
+       ,  const char* path = NULL) {
+    return node::ErrnoException(errorno, syscall, message, path);
+  }
+
+  NAN_DEPRECATED NAN_INLINE v8::Local<v8::Value> NanErrnoException(
+          int errorno
+       ,  const char* syscall = NULL
+       ,  const char* message = NULL
+       ,  const char* path = NULL) {
+    return ErrnoException(errorno, syscall, message, path);
+  }
+
+
+  template<typename T>
+  NAN_INLINE void SetIsolateData(
+      v8::Isolate *isolate
+    , T *data
+  ) {
+      isolate->SetData(data);
+  }
+
+  template<typename T>
+  NAN_INLINE T *GetIsolateData(
+      v8::Isolate *isolate
+  ) {
+      return static_cast<T*>(isolate->GetData());
+  }
+
+class Utf8String {
+ public:
+  NAN_INLINE explicit Utf8String(v8::Local<v8::Value> from) :
+      length_(0), str_(str_st_) {
+    if (!from.IsEmpty()) {
+      v8::Local<v8::String> string = from->ToString();
+      if (!string.IsEmpty()) {
+        size_t len = 3 * string->Length() + 1;
+        assert(len <= INT_MAX);
+        if (len > sizeof (str_st_)) {
+          str_ = static_cast<char*>(malloc(len));
+          assert(str_ != 0);
+        }
+        const int flags =
+            v8::String::NO_NULL_TERMINATION | imp::kReplaceInvalidUtf8;
+        length_ = string->WriteUtf8(str_, static_cast<int>(len), 0, flags);
+        str_[length_] = '\0';
+      }
+    }
+  }
+
+  NAN_INLINE int length() const {
+    return length_;
+  }
+
+  NAN_INLINE char* operator*() { return str_; }
+  NAN_INLINE const char* operator*() const { return str_; }
+
+  NAN_INLINE ~Utf8String() {
+    if (str_ != str_st_) {
+      free(str_);
+    }
+  }
+
+ private:
+  NAN_DISALLOW_ASSIGN_COPY_MOVE(Utf8String)
+
+  int length_;
+  char *str_;
+  char str_st_[1024];
+};
+
+#endif  // NODE_MODULE_VERSION
+
+typedef void (*FreeCallback)(char *data, void *hint);
+
+typedef const FunctionCallbackInfo<v8::Value>& NAN_METHOD_ARGS_TYPE;
+typedef void NAN_METHOD_RETURN_TYPE;
+
+typedef const PropertyCallbackInfo<v8::Value>& NAN_GETTER_ARGS_TYPE;
+typedef void NAN_GETTER_RETURN_TYPE;
+
+typedef const PropertyCallbackInfo<void>& NAN_SETTER_ARGS_TYPE;
+typedef void NAN_SETTER_RETURN_TYPE;
+
+typedef const PropertyCallbackInfo<v8::Value>&
+    NAN_PROPERTY_GETTER_ARGS_TYPE;
+typedef void NAN_PROPERTY_GETTER_RETURN_TYPE;
+
+typedef const PropertyCallbackInfo<v8::Value>&
+    NAN_PROPERTY_SETTER_ARGS_TYPE;
+typedef void NAN_PROPERTY_SETTER_RETURN_TYPE;
+
+typedef const PropertyCallbackInfo<v8::Array>&
+    NAN_PROPERTY_ENUMERATOR_ARGS_TYPE;
+typedef void NAN_PROPERTY_ENUMERATOR_RETURN_TYPE;
+
+typedef const PropertyCallbackInfo<v8::Boolean>&
+    NAN_PROPERTY_DELETER_ARGS_TYPE;
+typedef void NAN_PROPERTY_DELETER_RETURN_TYPE;
+
+typedef const PropertyCallbackInfo<v8::Integer>&
+    NAN_PROPERTY_QUERY_ARGS_TYPE;
+typedef void NAN_PROPERTY_QUERY_RETURN_TYPE;
+
+typedef const PropertyCallbackInfo<v8::Value>& NAN_INDEX_GETTER_ARGS_TYPE;
+typedef void NAN_INDEX_GETTER_RETURN_TYPE;
+
+typedef const PropertyCallbackInfo<v8::Value>& NAN_INDEX_SETTER_ARGS_TYPE;
+typedef void NAN_INDEX_SETTER_RETURN_TYPE;
+
+typedef const PropertyCallbackInfo<v8::Array>&
+    NAN_INDEX_ENUMERATOR_ARGS_TYPE;
+typedef void NAN_INDEX_ENUMERATOR_RETURN_TYPE;
+
+typedef const PropertyCallbackInfo<v8::Boolean>&
+    NAN_INDEX_DELETER_ARGS_TYPE;
+typedef void NAN_INDEX_DELETER_RETURN_TYPE;
+
+typedef const PropertyCallbackInfo<v8::Integer>&
+    NAN_INDEX_QUERY_ARGS_TYPE;
+typedef void NAN_INDEX_QUERY_RETURN_TYPE;
+
+#define NAN_METHOD(name)                                                       \
+    Nan::NAN_METHOD_RETURN_TYPE name(Nan::NAN_METHOD_ARGS_TYPE info)
+#define NAN_GETTER(name)                                                       \
+    Nan::NAN_GETTER_RETURN_TYPE name(                                          \
+        v8::Local<v8::String> property                                         \
+      , Nan::NAN_GETTER_ARGS_TYPE info)
+#define NAN_SETTER(name)                                                       \
+    Nan::NAN_SETTER_RETURN_TYPE name(                                          \
+        v8::Local<v8::String> property                                         \
+      , v8::Local<v8::Value> value                                             \
+      , Nan::NAN_SETTER_ARGS_TYPE info)
+#define NAN_PROPERTY_GETTER(name)                                              \
+    Nan::NAN_PROPERTY_GETTER_RETURN_TYPE name(                                 \
+        v8::Local<v8::String> property                                         \
+      , Nan::NAN_PROPERTY_GETTER_ARGS_TYPE info)
+#define NAN_PROPERTY_SETTER(name)                                              \
+    Nan::NAN_PROPERTY_SETTER_RETURN_TYPE name(                                 \
+        v8::Local<v8::String> property                                         \
+      , v8::Local<v8::Value> value                                             \
+      , Nan::NAN_PROPERTY_SETTER_ARGS_TYPE info)
+#define NAN_PROPERTY_ENUMERATOR(name)                                          \
+    Nan::NAN_PROPERTY_ENUMERATOR_RETURN_TYPE name(                             \
+        Nan::NAN_PROPERTY_ENUMERATOR_ARGS_TYPE info)
+#define NAN_PROPERTY_DELETER(name)                                             \
+    Nan::NAN_PROPERTY_DELETER_RETURN_TYPE name(                                \
+        v8::Local<v8::String> property                                         \
+      , Nan::NAN_PROPERTY_DELETER_ARGS_TYPE info)
+#define NAN_PROPERTY_QUERY(name)                                               \
+    Nan::NAN_PROPERTY_QUERY_RETURN_TYPE name(                                  \
+        v8::Local<v8::String> property                                         \
+      , Nan::NAN_PROPERTY_QUERY_ARGS_TYPE info)
+# define NAN_INDEX_GETTER(name)                                                \
+    Nan::NAN_INDEX_GETTER_RETURN_TYPE name(                                    \
+        uint32_t index                                                         \
+      , Nan::NAN_INDEX_GETTER_ARGS_TYPE info)
+#define NAN_INDEX_SETTER(name)                                                 \
+    Nan::NAN_INDEX_SETTER_RETURN_TYPE name(                                    \
+        uint32_t index                                                         \
+      , v8::Local<v8::Value> value                                             \
+      , Nan::NAN_INDEX_SETTER_ARGS_TYPE info)
+#define NAN_INDEX_ENUMERATOR(name)                                             \
+    Nan::NAN_INDEX_ENUMERATOR_RETURN_TYPE                                      \
+    name(Nan::NAN_INDEX_ENUMERATOR_ARGS_TYPE info)
+#define NAN_INDEX_DELETER(name)                                                \
+    Nan::NAN_INDEX_DELETER_RETURN_TYPE name(                                   \
+        uint32_t index                                                         \
+      , Nan::NAN_INDEX_DELETER_ARGS_TYPE info)
+#define NAN_INDEX_QUERY(name)                                                  \
+    Nan::NAN_INDEX_QUERY_RETURN_TYPE name(                                     \
+        uint32_t index                                                         \
+      , Nan::NAN_INDEX_QUERY_ARGS_TYPE info)
+
+class Callback {
+ public:
+  Callback() {
+    HandleScope scope;
+    v8::Local<v8::Object> obj = New<v8::Object>();
+    handle.Reset(obj);
+  }
+
+  explicit Callback(const v8::Local<v8::Function> &fn) {
+    HandleScope scope;
+    v8::Local<v8::Object> obj = New<v8::Object>();
+    handle.Reset(obj);
+    SetFunction(fn);
+  }
+
+  ~Callback() {
+    if (handle.IsEmpty()) return;
+    handle.Reset();
+  }
+
+  bool operator==(const Callback &other) const {
+    HandleScope scope;
+    v8::Local<v8::Value> a = New(handle)->Get(kCallbackIndex);
+    v8::Local<v8::Value> b = New(other.handle)->Get(kCallbackIndex);
+    return a->StrictEquals(b);
+  }
+
+  bool operator!=(const Callback &other) const {
+    return !this->operator==(other);
+  }
+
+  NAN_INLINE
+  v8::Local<v8::Function> operator*() const { return this->GetFunction(); }
+
+  NAN_INLINE v8::Local<v8::Value> operator()(
+      v8::Local<v8::Object> target
+    , int argc = 0
+    , v8::Local<v8::Value> argv[] = 0) const {
+    return this->Call(target, argc, argv);
+  }
+
+  NAN_INLINE v8::Local<v8::Value> operator()(
+      int argc = 0
+    , v8::Local<v8::Value> argv[] = 0) const {
+    return this->Call(argc, argv);
+  }
+
+  NAN_INLINE void SetFunction(const v8::Local<v8::Function> &fn) {
+    HandleScope scope;
+    Set(New(handle), kCallbackIndex, fn);
+  }
+
+  NAN_INLINE v8::Local<v8::Function> GetFunction() const {
+    EscapableHandleScope scope;
+    return scope.Escape(New(handle)->Get(kCallbackIndex)
+        .As<v8::Function>());
+  }
+
+  NAN_INLINE bool IsEmpty() const {
+    HandleScope scope;
+    return New(handle)->Get(kCallbackIndex)->IsUndefined();
+  }
+
+  NAN_INLINE v8::Local<v8::Value>
+  Call(v8::Local<v8::Object> target
+     , int argc
+     , v8::Local<v8::Value> argv[]) const {
+#if (NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION)
+    v8::Isolate *isolate = v8::Isolate::GetCurrent();
+    return Call_(isolate, target, argc, argv);
+#else
+    return Call_(target, argc, argv);
+#endif
+  }
+
+  NAN_INLINE v8::Local<v8::Value>
+  Call(int argc, v8::Local<v8::Value> argv[]) const {
+#if (NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION)
+    v8::Isolate *isolate = v8::Isolate::GetCurrent();
+    return Call_(isolate, isolate->GetCurrentContext()->Global(), argc, argv);
+#else
+    return Call_(v8::Context::GetCurrent()->Global(), argc, argv);
+#endif
+  }
+
+ private:
+  NAN_DISALLOW_ASSIGN_COPY_MOVE(Callback)
+  Persistent<v8::Object> handle;
+  static const uint32_t kCallbackIndex = 0;
+
+#if (NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION)
+  v8::Local<v8::Value> Call_(v8::Isolate *isolate
+                           , v8::Local<v8::Object> target
+                           , int argc
+                           , v8::Local<v8::Value> argv[]) const {
+    EscapableHandleScope scope;
+
+    v8::Local<v8::Function> callback = New(handle)->
+        Get(kCallbackIndex).As<v8::Function>();
+# if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
+    return scope.Escape(New(node::MakeCallback(
+        isolate
+      , target
+      , callback
+      , argc
+      , argv
+    )));
+# else
+    return scope.Escape(node::MakeCallback(
+        isolate
+      , target
+      , callback
+      , argc
+      , argv
+    ));
+# endif
+  }
+#else
+  v8::Local<v8::Value> Call_(v8::Local<v8::Object> target
+                           , int argc
+                           , v8::Local<v8::Value> argv[]) const {
+    EscapableHandleScope scope;
+
+    v8::Local<v8::Function> callback = New(handle)->
+        Get(kCallbackIndex).As<v8::Function>();
+    return scope.Escape(New(node::MakeCallback(
+        target
+      , callback
+      , argc
+      , argv
+    )));
+  }
+#endif
+};
+
+/* abstract */ class AsyncWorker {
+ public:
+  explicit AsyncWorker(Callback *callback_)
+      : callback(callback_), errmsg_(NULL) {
+    request.data = this;
+
+    HandleScope scope;
+    v8::Local<v8::Object> obj = New<v8::Object>();
+    persistentHandle.Reset(obj);
+  }
+
+  virtual ~AsyncWorker() {
+    HandleScope scope;
+
+    if (!persistentHandle.IsEmpty())
+      persistentHandle.Reset();
+    if (callback)
+      delete callback;
+    if (errmsg_)
+      delete[] errmsg_;
+  }
+
+  virtual void WorkComplete() {
+    HandleScope scope;
+
+    if (errmsg_ == NULL)
+      HandleOKCallback();
+    else
+      HandleErrorCallback();
+    delete callback;
+    callback = NULL;
+  }
+
+  NAN_INLINE void SaveToPersistent(
+      const char *key, const v8::Local<v8::Value> &value) {
+    HandleScope scope;
+    New(persistentHandle)->Set(New(key).ToLocalChecked(), value);
+  }
+
+  NAN_INLINE void SaveToPersistent(
+      const v8::Local<v8::String> &key, const v8::Local<v8::Value> &value) {
+    HandleScope scope;
+    New(persistentHandle)->Set(key, value);
+  }
+
+  NAN_INLINE void SaveToPersistent(
+      uint32_t index, const v8::Local<v8::Value> &value) {
+    HandleScope scope;
+    New(persistentHandle)->Set(index, value);
+  }
+
+  NAN_INLINE v8::Local<v8::Value> GetFromPersistent(const char *key) const {
+    EscapableHandleScope scope;
+    return scope.Escape(
+        New(persistentHandle)->Get(New(key).ToLocalChecked()));
+  }
+
+  NAN_INLINE v8::Local<v8::Value>
+  GetFromPersistent(const v8::Local<v8::String> &key) const {
+    EscapableHandleScope scope;
+    return scope.Escape(New(persistentHandle)->Get(key));
+  }
+
+  NAN_INLINE v8::Local<v8::Value> GetFromPersistent(uint32_t index) const {
+    EscapableHandleScope scope;
+    return scope.Escape(New(persistentHandle)->Get(index));
+  }
+
+  virtual void Execute() = 0;
+
+  uv_work_t request;
+
+  virtual void Destroy() {
+      delete this;
+  }
+
+ protected:
+  Persistent<v8::Object> persistentHandle;
+  Callback *callback;
+
+  virtual void HandleOKCallback() {
+    callback->Call(0, NULL);
+  }
+
+  virtual void HandleErrorCallback() {
+    HandleScope scope;
+
+    v8::Local<v8::Value> argv[] = {
+      v8::Exception::Error(New<v8::String>(ErrorMessage()).ToLocalChecked())
+    };
+    callback->Call(1, argv);
+  }
+
+  void SetErrorMessage(const char *msg) {
+    if (errmsg_) {
+      delete[] errmsg_;
+    }
+
+    size_t size = strlen(msg) + 1;
+    errmsg_ = new char[size];
+    memcpy(errmsg_, msg, size);
+  }
+
+  const char* ErrorMessage() const {
+    return errmsg_;
+  }
+
+ private:
+  NAN_DISALLOW_ASSIGN_COPY_MOVE(AsyncWorker)
+  char *errmsg_;
+};
+
+/* abstract */ class AsyncProgressWorker : public AsyncWorker {
+ public:
+  explicit AsyncProgressWorker(Callback *callback_)
+      : AsyncWorker(callback_), asyncdata_(NULL), asyncsize_(0) {
+    async = new uv_async_t;
+    uv_async_init(
+        uv_default_loop()
+      , async
+      , AsyncProgress_
+    );
+    async->data = this;
+
+    uv_mutex_init(&async_lock);
+  }
+
+  virtual ~AsyncProgressWorker() {
+    uv_mutex_destroy(&async_lock);
+
+    if (asyncdata_) {
+      delete[] asyncdata_;
+    }
+  }
+
+  void WorkProgress() {
+    uv_mutex_lock(&async_lock);
+    char *data = asyncdata_;
+    size_t size = asyncsize_;
+    asyncdata_ = NULL;
+    uv_mutex_unlock(&async_lock);
+
+    // Dont send progress events after we've already completed.
+    if (callback) {
+        HandleProgressCallback(data, size);
+    }
+    delete[] data;
+  }
+
+  class ExecutionProgress {
+    friend class AsyncProgressWorker;
+   public:
+    // You could do fancy generics with templates here.
+    void Send(const char* data, size_t size) const {
+        that_->SendProgress_(data, size);
+    }
+
+   private:
+    explicit ExecutionProgress(AsyncProgressWorker* that) : that_(that) {}
+    NAN_DISALLOW_ASSIGN_COPY_MOVE(ExecutionProgress)
+    AsyncProgressWorker* const that_;
+  };
+
+  virtual void Execute(const ExecutionProgress& progress) = 0;
+  virtual void HandleProgressCallback(const char *data, size_t size) = 0;
+
+  virtual void Destroy() {
+      uv_close(reinterpret_cast<uv_handle_t*>(async), AsyncClose_);
+  }
+
+ private:
+  void Execute() /*final override*/ {
+      ExecutionProgress progress(this);
+      Execute(progress);
+  }
+
+  void SendProgress_(const char *data, size_t size) {
+    char *new_data = new char[size];
+    memcpy(new_data, data, size);
+
+    uv_mutex_lock(&async_lock);
+    char *old_data = asyncdata_;
+    asyncdata_ = new_data;
+    asyncsize_ = size;
+    uv_mutex_unlock(&async_lock);
+
+    if (old_data) {
+      delete[] old_data;
+    }
+    uv_async_send(async);
+  }
+
+  NAN_INLINE static NAUV_WORK_CB(AsyncProgress_) {
+    AsyncProgressWorker *worker =
+            static_cast<AsyncProgressWorker*>(async->data);
+    worker->WorkProgress();
+  }
+
+  NAN_INLINE static void AsyncClose_(uv_handle_t* handle) {
+    AsyncProgressWorker *worker =
+            static_cast<AsyncProgressWorker*>(handle->data);
+    delete reinterpret_cast<uv_async_t*>(handle);
+    delete worker;
+  }
+
+  uv_async_t *async;
+  uv_mutex_t async_lock;
+  char *asyncdata_;
+  size_t asyncsize_;
+};
+
+NAN_INLINE void AsyncExecute (uv_work_t* req) {
+  AsyncWorker *worker = static_cast<AsyncWorker*>(req->data);
+  worker->Execute();
+}
+
+NAN_INLINE void AsyncExecuteComplete (uv_work_t* req) {
+  AsyncWorker* worker = static_cast<AsyncWorker*>(req->data);
+  worker->WorkComplete();
+  worker->Destroy();
+}
+
+NAN_INLINE void AsyncQueueWorker (AsyncWorker* worker) {
+  uv_queue_work(
+      uv_default_loop()
+    , &worker->request
+    , AsyncExecute
+    , (uv_after_work_cb)AsyncExecuteComplete
+  );
+}
+
+namespace imp {
+
+inline
+ExternalOneByteStringResource const*
+GetExternalResource(v8::Local<v8::String> str) {
+#if NODE_MODULE_VERSION < ATOM_0_21_MODULE_VERSION
+    return str->GetExternalAsciiStringResource();
+#else
+    return str->GetExternalOneByteStringResource();
+#endif
+}
+
+inline
+bool
+IsExternal(v8::Local<v8::String> str) {
+#if NODE_MODULE_VERSION < ATOM_0_21_MODULE_VERSION
+    return str->IsExternalAscii();
+#else
+    return str->IsExternalOneByte();
+#endif
+}
+
+}  // end of namespace imp
+
+enum Encoding {ASCII, UTF8, BASE64, UCS2, BINARY, HEX, BUFFER};
+
+#if NODE_MODULE_VERSION < NODE_0_10_MODULE_VERSION
+# include "nan_string_bytes.h"  // NOLINT(build/include)
+#endif
+
+NAN_INLINE v8::Local<v8::Value> Encode(
+    const void *buf, size_t len, enum Encoding encoding = BINARY) {
+#if (NODE_MODULE_VERSION >= ATOM_0_21_MODULE_VERSION)
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  node::encoding node_enc = static_cast<node::encoding>(encoding);
+
+  if (encoding == UCS2) {
+    return node::Encode(
+        isolate
+      , reinterpret_cast<const uint16_t *>(buf)
+      , len / 2);
+  } else {
+    return node::Encode(
+        isolate
+      , reinterpret_cast<const char *>(buf)
+      , len
+      , node_enc);
+  }
+#elif (NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION)
+  return node::Encode(
+      v8::Isolate::GetCurrent()
+    , buf, len
+    , static_cast<node::encoding>(encoding));
+#else
+# if NODE_MODULE_VERSION >= NODE_0_10_MODULE_VERSION
+  return node::Encode(buf, len, static_cast<node::encoding>(encoding));
+# else
+  return imp::Encode(reinterpret_cast<const char*>(buf), len, encoding);
+# endif
+#endif
+}
+
+NAN_INLINE ssize_t DecodeBytes(
+    v8::Local<v8::Value> val, enum Encoding encoding = BINARY) {
+#if (NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION)
+  return node::DecodeBytes(
+      v8::Isolate::GetCurrent()
+    , val
+    , static_cast<node::encoding>(encoding));
+#else
+# if (NODE_MODULE_VERSION < NODE_0_10_MODULE_VERSION)
+  if (encoding == BUFFER) {
+    return node::DecodeBytes(val, node::BINARY);
+  }
+# endif
+  return node::DecodeBytes(val, static_cast<node::encoding>(encoding));
+#endif
+}
+
+NAN_INLINE ssize_t DecodeWrite(
+    char *buf
+  , size_t len
+  , v8::Local<v8::Value> val
+  , enum Encoding encoding = BINARY) {
+#if (NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION)
+  return node::DecodeWrite(
+      v8::Isolate::GetCurrent()
+    , buf
+    , len
+    , val
+    , static_cast<node::encoding>(encoding));
+#else
+# if (NODE_MODULE_VERSION < NODE_0_10_MODULE_VERSION)
+  if (encoding == BUFFER) {
+    return node::DecodeWrite(buf, len, val, node::BINARY);
+  }
+# endif
+  return node::DecodeWrite(
+      buf
+    , len
+    , val
+    , static_cast<node::encoding>(encoding));
+#endif
+}
+
+NAN_INLINE void SetPrototypeTemplate(
+    v8::Local<v8::FunctionTemplate> templ
+  , const char *name
+  , v8::Local<v8::Data> value
+) {
+  SetTemplate(templ->PrototypeTemplate(), name, value);
+}
+
+NAN_INLINE void SetPrototypeTemplate(
+    v8::Local<v8::FunctionTemplate> templ
+  , v8::Local<v8::String> name
+  , v8::Local<v8::Data> value
+  , v8::PropertyAttribute attributes
+) {
+  SetTemplate(templ->PrototypeTemplate(), name, value, attributes);
+}
+
+NAN_INLINE void SetInstanceTemplate(
+    v8::Local<v8::FunctionTemplate> templ
+  , const char *name
+  , v8::Local<v8::Data> value
+) {
+  SetTemplate(templ->InstanceTemplate(), name, value);
+}
+
+NAN_INLINE void SetInstanceTemplate(
+    v8::Local<v8::FunctionTemplate> templ
+  , v8::Local<v8::String> name
+  , v8::Local<v8::Data> value
+  , v8::PropertyAttribute attributes
+) {
+  SetTemplate(templ->InstanceTemplate(), name, value, attributes);
+}
+
+template<typename T>
+NAN_INLINE void SetMethod(
+    const T &recv
+  , const char *name
+  , FunctionCallback callback) {
+  HandleScope scope;
+  v8::Local<v8::Function> fn = GetFunction(New<v8::FunctionTemplate>(
+      callback)).ToLocalChecked();
+  v8::Local<v8::String> fn_name = New(name).ToLocalChecked();
+  fn->SetName(fn_name);
+  recv->Set(fn_name, fn);
+}
+
+NAN_INLINE void SetPrototypeMethod(
+    v8::Local<v8::FunctionTemplate> recv
+  , const char* name, FunctionCallback callback) {
+  HandleScope scope;
+  v8::Local<v8::Function> fn = GetFunction(New<v8::FunctionTemplate>(
+      callback
+    , v8::Local<v8::Value>()
+    , New<v8::Signature>(recv))).ToLocalChecked();
+  v8::Local<v8::String> fn_name = New(name).ToLocalChecked();
+  recv->PrototypeTemplate()->Set(fn_name, fn);
+  fn->SetName(fn_name);
+}
+
+//=== Accessors and Such =======================================================
+
+inline void SetAccessor(
+    v8::Local<v8::ObjectTemplate> tpl
+  , v8::Local<v8::String> name
+  , GetterCallback getter
+  , SetterCallback setter = 0
+  , v8::Local<v8::Value> data = v8::Local<v8::Value>()
+  , v8::AccessControl settings = v8::DEFAULT
+  , v8::PropertyAttribute attribute = v8::None
+  , imp::Sig signature = imp::Sig()) {
+  HandleScope scope;
+
+  imp::NativeGetter getter_ =
+      imp::GetterCallbackWrapper;
+  imp::NativeSetter setter_ =
+      setter ? imp::SetterCallbackWrapper : 0;
+
+  v8::Local<v8::ObjectTemplate> otpl = New<v8::ObjectTemplate>();
+  otpl->SetInternalFieldCount(imp::kAccessorFieldCount);
+  v8::Local<v8::Object> obj = NewInstance(otpl).ToLocalChecked();
+
+  obj->SetInternalField(
+      imp::kGetterIndex
+    , New<v8::External>(reinterpret_cast<void *>(getter)));
+
+  if (setter != 0) {
+    obj->SetInternalField(
+        imp::kSetterIndex
+      , New<v8::External>(reinterpret_cast<void *>(setter)));
+  }
+
+  if (!data.IsEmpty()) {
+    obj->SetInternalField(imp::kDataIndex, data);
+  }
+
+  tpl->SetAccessor(
+      name
+    , getter_
+    , setter_
+    , obj
+    , settings
+    , attribute
+    , signature);
+}
+
+inline bool SetAccessor(
+    v8::Local<v8::Object> obj
+  , v8::Local<v8::String> name
+  , GetterCallback getter
+  , SetterCallback setter = 0
+  , v8::Local<v8::Value> data = v8::Local<v8::Value>()
+  , v8::AccessControl settings = v8::DEFAULT
+  , v8::PropertyAttribute attribute = v8::None) {
+  EscapableHandleScope scope;
+
+  imp::NativeGetter getter_ =
+      imp::GetterCallbackWrapper;
+  imp::NativeSetter setter_ =
+      setter ? imp::SetterCallbackWrapper : 0;
+
+  v8::Local<v8::ObjectTemplate> otpl = New<v8::ObjectTemplate>();
+  otpl->SetInternalFieldCount(imp::kAccessorFieldCount);
+  v8::Local<v8::Object> dataobj = NewInstance(otpl).ToLocalChecked();
+
+  dataobj->SetInternalField(
+      imp::kGetterIndex
+    , New<v8::External>(reinterpret_cast<void *>(getter)));
+
+  if (!data.IsEmpty()) {
+    dataobj->SetInternalField(imp::kDataIndex, data);
+  }
+
+  if (setter) {
+    dataobj->SetInternalField(
+        imp::kSetterIndex
+      , New<v8::External>(reinterpret_cast<void *>(setter)));
+  }
+
+  return obj->SetAccessor(
+      name
+    , getter_
+    , setter_
+    , dataobj
+    , settings
+    , attribute);
+}
+
+inline void SetNamedPropertyHandler(
+    v8::Local<v8::ObjectTemplate> tpl
+  , PropertyGetterCallback getter
+  , PropertySetterCallback setter = 0
+  , PropertyQueryCallback query = 0
+  , PropertyDeleterCallback deleter = 0
+  , PropertyEnumeratorCallback enumerator = 0
+  , v8::Local<v8::Value> data = v8::Local<v8::Value>()) {
+  HandleScope scope;
+
+  imp::NativePropertyGetter getter_ =
+      imp::PropertyGetterCallbackWrapper;
+  imp::NativePropertySetter setter_ =
+      setter ? imp::PropertySetterCallbackWrapper : 0;
+  imp::NativePropertyQuery query_ =
+      query ? imp::PropertyQueryCallbackWrapper : 0;
+  imp::NativePropertyDeleter *deleter_ =
+      deleter ? imp::PropertyDeleterCallbackWrapper : 0;
+  imp::NativePropertyEnumerator enumerator_ =
+      enumerator ? imp::PropertyEnumeratorCallbackWrapper : 0;
+
+  v8::Local<v8::ObjectTemplate> otpl = New<v8::ObjectTemplate>();
+  otpl->SetInternalFieldCount(imp::kPropertyFieldCount);
+  v8::Local<v8::Object> obj = NewInstance(otpl).ToLocalChecked();
+  obj->SetInternalField(
+      imp::kPropertyGetterIndex
+    , New<v8::External>(reinterpret_cast<void *>(getter)));
+
+  if (setter) {
+    obj->SetInternalField(
+        imp::kPropertySetterIndex
+      , New<v8::External>(reinterpret_cast<void *>(setter)));
+  }
+
+  if (query) {
+    obj->SetInternalField(
+        imp::kPropertyQueryIndex
+      , New<v8::External>(reinterpret_cast<void *>(query)));
+  }
+
+  if (deleter) {
+    obj->SetInternalField(
+        imp::kPropertyDeleterIndex
+      , New<v8::External>(reinterpret_cast<void *>(deleter)));
+  }
+
+  if (enumerator) {
+    obj->SetInternalField(
+        imp::kPropertyEnumeratorIndex
+      , New<v8::External>(reinterpret_cast<void *>(enumerator)));
+  }
+
+  if (!data.IsEmpty()) {
+    obj->SetInternalField(imp::kDataIndex, data);
+  }
+
+#if NODE_MODULE_VERSION > NODE_0_12_MODULE_VERSION
+  tpl->SetHandler(v8::NamedPropertyHandlerConfiguration(
+      getter_, setter_, query_, deleter_, enumerator_, obj));
+#else
+  tpl->SetNamedPropertyHandler(
+      getter_
+    , setter_
+    , query_
+    , deleter_
+    , enumerator_
+    , obj);
+#endif
+}
+
+inline void SetIndexedPropertyHandler(
+    v8::Local<v8::ObjectTemplate> tpl
+  , IndexGetterCallback getter
+  , IndexSetterCallback setter = 0
+  , IndexQueryCallback query = 0
+  , IndexDeleterCallback deleter = 0
+  , IndexEnumeratorCallback enumerator = 0
+  , v8::Local<v8::Value> data = v8::Local<v8::Value>()) {
+  HandleScope scope;
+
+  imp::NativeIndexGetter getter_ =
+      imp::IndexGetterCallbackWrapper;
+  imp::NativeIndexSetter setter_ =
+      setter ? imp::IndexSetterCallbackWrapper : 0;
+  imp::NativeIndexQuery query_ =
+      query ? imp::IndexQueryCallbackWrapper : 0;
+  imp::NativeIndexDeleter deleter_ =
+      deleter ? imp::IndexDeleterCallbackWrapper : 0;
+  imp::NativeIndexEnumerator enumerator_ =
+      enumerator ? imp::IndexEnumeratorCallbackWrapper : 0;
+
+  v8::Local<v8::ObjectTemplate> otpl = New<v8::ObjectTemplate>();
+  otpl->SetInternalFieldCount(imp::kIndexPropertyFieldCount);
+  v8::Local<v8::Object> obj = NewInstance(otpl).ToLocalChecked();
+  obj->SetInternalField(
+      imp::kIndexPropertyGetterIndex
+    , New<v8::External>(reinterpret_cast<void *>(getter)));
+
+  if (setter) {
+    obj->SetInternalField(
+        imp::kIndexPropertySetterIndex
+      , New<v8::External>(reinterpret_cast<void *>(setter)));
+  }
+
+  if (query) {
+    obj->SetInternalField(
+        imp::kIndexPropertyQueryIndex
+      , New<v8::External>(reinterpret_cast<void *>(query)));
+  }
+
+  if (deleter) {
+    obj->SetInternalField(
+        imp::kIndexPropertyDeleterIndex
+      , New<v8::External>(reinterpret_cast<void *>(deleter)));
+  }
+
+  if (enumerator) {
+    obj->SetInternalField(
+        imp::kIndexPropertyEnumeratorIndex
+      , New<v8::External>(reinterpret_cast<void *>(enumerator)));
+  }
+
+  if (!data.IsEmpty()) {
+    obj->SetInternalField(imp::kDataIndex, data);
+  }
+
+#if NODE_MODULE_VERSION > NODE_0_12_MODULE_VERSION
+  tpl->SetHandler(v8::IndexedPropertyHandlerConfiguration(
+      getter_, setter_, query_, deleter_, enumerator_, obj));
+#else
+  tpl->SetIndexedPropertyHandler(
+      getter_
+    , setter_
+    , query_
+    , deleter_
+    , enumerator_
+    , obj);
+#endif
+}
+
+inline void SetCallHandler(
+    v8::Local<v8::FunctionTemplate> tpl
+  , FunctionCallback callback
+  , v8::Local<v8::Value> data = v8::Local<v8::Value>()) {
+  HandleScope scope;
+
+  v8::Local<v8::ObjectTemplate> otpl = New<v8::ObjectTemplate>();
+  otpl->SetInternalFieldCount(imp::kFunctionFieldCount);
+  v8::Local<v8::Object> obj = NewInstance(otpl).ToLocalChecked();
+
+  obj->SetInternalField(
+      imp::kFunctionIndex
+    , New<v8::External>(reinterpret_cast<void *>(callback)));
+
+  if (!data.IsEmpty()) {
+    obj->SetInternalField(imp::kDataIndex, data);
+  }
+
+  tpl->SetCallHandler(imp::FunctionCallbackWrapper, obj);
+}
+
+
+inline void SetCallAsFunctionHandler(
+    v8::Local<v8::ObjectTemplate> tpl,
+    FunctionCallback callback,
+    v8::Local<v8::Value> data = v8::Local<v8::Value>()) {
+  HandleScope scope;
+
+  v8::Local<v8::ObjectTemplate> otpl = New<v8::ObjectTemplate>();
+  otpl->SetInternalFieldCount(imp::kFunctionFieldCount);
+  v8::Local<v8::Object> obj = NewInstance(otpl).ToLocalChecked();
+
+  obj->SetInternalField(
+      imp::kFunctionIndex
+    , New<v8::External>(reinterpret_cast<void *>(callback)));
+
+  if (!data.IsEmpty()) {
+    obj->SetInternalField(imp::kDataIndex, data);
+  }
+
+  tpl->SetCallAsFunctionHandler(imp::FunctionCallbackWrapper, obj);
+}
+
+//=== Weak Persistent Handling =================================================
+
+#include "nan_weak.h"  // NOLINT(build/include)
+
+//=== ObjectWrap ===============================================================
+
+#include "nan_object_wrap.h"  // NOLINT(build/include)
+
+//=== Export ==================================================================
+
+inline
+void
+Export(ADDON_REGISTER_FUNCTION_ARGS_TYPE target, const char *name,
+    FunctionCallback f) {
+  Set(target, New<v8::String>(name).ToLocalChecked(),
+      GetFunction(New<v8::FunctionTemplate>(f)).ToLocalChecked());
+}
+
+//=== Tap Reverse Binding =====================================================
+
+struct Tap {
+  explicit Tap(v8::Local<v8::Value> t) : t_() {
+    t_.Reset(To<v8::Object>(t).ToLocalChecked());
+  }
+
+  ~Tap() { t_.Reset(); }  // not sure if neccessary
+
+  inline void plan(int i) {
+    v8::Local<v8::Value> arg = New(i);
+    MakeCallback(New(t_), "plan", 1, &arg);
+  }
+
+  inline void ok(bool isOk, const char *msg = NULL) {
+    v8::Local<v8::Value> args[2];
+    args[0] = New(isOk);
+    if (msg) args[1] = New(msg).ToLocalChecked();
+    MakeCallback(New(t_), "ok", msg ? 2 : 1, args);
+  }
+
+  inline void pass(const char * msg = NULL) {
+    v8::Local<v8::Value> hmsg;
+    if (msg) hmsg = New(msg).ToLocalChecked();
+    MakeCallback(New(t_), "pass", msg ? 1 : 0, &hmsg);
+  }
+
+ private:
+  Persistent<v8::Object> t_;
+};
+
+#define NAN_STRINGIZE2(x) #x
+#define NAN_STRINGIZE(x) NAN_STRINGIZE2(x)
+#define NAN_TEST_EXPRESSION(expression) \
+  ( expression ), __FILE__ ":" NAN_STRINGIZE(__LINE__) ": " #expression
+
+#define NAN_EXPORT(target, function) Export(target, #function, function)
+
+#undef TYPE_CHECK
+
+//=== Generic Maybefication ===================================================
+
+namespace imp {
+
+template <typename T> struct Maybefier;
+
+template <typename T> struct Maybefier<v8::Local<T> > {
+  static MaybeLocal<T> convert(v8::Local<T> v) {
+    return MaybeLocal<T>(v);
+  }
+};
+
+template <typename T> struct Maybefier<MaybeLocal<T> > {
+  static MaybeLocal<T> convert(MaybeLocal<T> v) {
+    return v;
+  }
+};
+
+}  // end of namespace imp
+
+template <typename T, template <typename> class MaybeMaybe>
+MaybeLocal<T>
+MakeMaybe(MaybeMaybe<T> v) {
+  return imp::Maybefier<MaybeMaybe<T> >::convert(v);
+}
+
+//=== TypedArrayContents =======================================================
+
+#include "nan_typedarray_contents.h"  // NOLINT(build/include)
+
+}  // end of namespace Nan
+
+#endif  // NAN_H_

--- a/deps/nan/nan_callbacks.h
+++ b/deps/nan/nan_callbacks.h
@@ -1,0 +1,88 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2015 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+#ifndef NAN_CALLBACKS_H_
+#define NAN_CALLBACKS_H_
+
+template<typename T> class FunctionCallbackInfo;
+template<typename T> class PropertyCallbackInfo;
+template<typename T> class Global;
+
+typedef void(*FunctionCallback)(const FunctionCallbackInfo<v8::Value>&);
+typedef void(*GetterCallback)
+    (v8::Local<v8::String>, const PropertyCallbackInfo<v8::Value>&);
+typedef void(*SetterCallback)(
+    v8::Local<v8::String>,
+    v8::Local<v8::Value>,
+    const PropertyCallbackInfo<void>&);
+typedef void(*PropertyGetterCallback)(
+    v8::Local<v8::String>,
+    const PropertyCallbackInfo<v8::Value>&);
+typedef void(*PropertySetterCallback)(
+    v8::Local<v8::String>,
+    v8::Local<v8::Value>,
+    const PropertyCallbackInfo<v8::Value>&);
+typedef void(*PropertyEnumeratorCallback)
+    (const PropertyCallbackInfo<v8::Array>&);
+typedef void(*PropertyDeleterCallback)(
+    v8::Local<v8::String>,
+    const PropertyCallbackInfo<v8::Boolean>&);
+typedef void(*PropertyQueryCallback)(
+    v8::Local<v8::String>,
+    const PropertyCallbackInfo<v8::Integer>&);
+typedef void(*IndexGetterCallback)(
+    uint32_t,
+    const PropertyCallbackInfo<v8::Value>&);
+typedef void(*IndexSetterCallback)(
+    uint32_t,
+    v8::Local<v8::Value>,
+    const PropertyCallbackInfo<v8::Value>&);
+typedef void(*IndexEnumeratorCallback)
+    (const PropertyCallbackInfo<v8::Array>&);
+typedef void(*IndexDeleterCallback)(
+    uint32_t,
+    const PropertyCallbackInfo<v8::Boolean>&);
+typedef void(*IndexQueryCallback)(
+    uint32_t,
+    const PropertyCallbackInfo<v8::Integer>&);
+
+namespace imp {
+typedef v8::Local<v8::AccessorSignature> Sig;
+
+static const int kDataIndex =                    0;
+
+static const int kFunctionIndex =                1;
+static const int kFunctionFieldCount =           2;
+
+static const int kGetterIndex =                  1;
+static const int kSetterIndex =                  2;
+static const int kAccessorFieldCount =           3;
+
+static const int kPropertyGetterIndex =          1;
+static const int kPropertySetterIndex =          2;
+static const int kPropertyEnumeratorIndex =      3;
+static const int kPropertyDeleterIndex =         4;
+static const int kPropertyQueryIndex =           5;
+static const int kPropertyFieldCount =           6;
+
+static const int kIndexPropertyGetterIndex =     1;
+static const int kIndexPropertySetterIndex =     2;
+static const int kIndexPropertyEnumeratorIndex = 3;
+static const int kIndexPropertyDeleterIndex =    4;
+static const int kIndexPropertyQueryIndex =      5;
+static const int kIndexPropertyFieldCount =      6;
+
+}  // end of namespace imp
+
+#if NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION
+# include "nan_callbacks_12_inl.h"  // NOLINT(build/include)
+#else
+# include "nan_callbacks_pre_12_inl.h"  // NOLINT(build/include)
+#endif
+
+#endif  // NAN_CALLBACKS_H_

--- a/deps/nan/nan_callbacks_12_inl.h
+++ b/deps/nan/nan_callbacks_12_inl.h
@@ -1,0 +1,512 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2015 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+#ifndef NAN_CALLBACKS_12_INL_H_
+#define NAN_CALLBACKS_12_INL_H_
+
+template<typename T>
+class ReturnValue {
+  v8::ReturnValue<T> value_;
+
+ public:
+  template <class S>
+  explicit inline ReturnValue(const v8::ReturnValue<S> &value) :
+      value_(value) {}
+  template <class S>
+  explicit inline ReturnValue(const ReturnValue<S>& that)
+      : value_(that.value_) {
+    TYPE_CHECK(T, S);
+  }
+
+  // Handle setters
+  template <typename S> inline void Set(const v8::Local<S> &handle) {
+    TYPE_CHECK(T, S);
+    value_.Set(handle);
+  }
+
+  template <typename S> inline void Set(const Global<S> &handle) {
+    TYPE_CHECK(T, S);
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
+  (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) &&                       \
+  (V8_MINOR_VERSION > 5 || (V8_MINOR_VERSION == 5 &&                           \
+  defined(V8_BUILD_NUMBER) && V8_BUILD_NUMBER >= 8))))
+    value_.Set(handle);
+#else
+    value_.Set(*reinterpret_cast<const v8::Persistent<S>*>(&handle));
+    const_cast<Global<S> &>(handle).Reset();
+#endif
+  }
+
+  // Fast primitive setters
+  inline void Set(bool value) {
+    TYPE_CHECK(T, v8::Boolean);
+    value_.Set(value);
+  }
+
+  inline void Set(double i) {
+    TYPE_CHECK(T, v8::Number);
+    value_.Set(i);
+  }
+
+  inline void Set(int32_t i) {
+    TYPE_CHECK(T, v8::Integer);
+    value_.Set(i);
+  }
+
+  inline void Set(uint32_t i) {
+    TYPE_CHECK(T, v8::Integer);
+    value_.Set(i);
+  }
+
+  // Fast JS primitive setters
+  inline void SetNull() {
+    TYPE_CHECK(T, v8::Primitive);
+    value_.SetNull();
+  }
+
+  inline void SetUndefined() {
+    TYPE_CHECK(T, v8::Primitive);
+    value_.SetUndefined();
+  }
+
+  inline void SetEmptyString() {
+    TYPE_CHECK(T, v8::String);
+    value_.SetEmptyString();
+  }
+
+  // Convenience getter for isolate
+  inline v8::Isolate *GetIsolate() const {
+    return value_.GetIsolate();
+  }
+
+  // Pointer setter: Uncompilable to prevent inadvertent misuse.
+  template<typename S>
+  inline void Set(S *whatever) { TYPE_CHECK(S*, v8::Primitive); }
+};
+
+template<typename T>
+class FunctionCallbackInfo {
+  const v8::FunctionCallbackInfo<T> &info_;
+  const v8::Local<v8::Value> data_;
+
+ public:
+  explicit inline FunctionCallbackInfo(
+      const v8::FunctionCallbackInfo<T> &info
+    , v8::Local<v8::Value> data) :
+          info_(info)
+        , data_(data) {}
+
+  inline ReturnValue<T> GetReturnValue() const {
+    return ReturnValue<T>(info_.GetReturnValue());
+  }
+
+  inline v8::Local<v8::Function> Callee() const { return info_.Callee(); }
+  inline v8::Local<v8::Value> Data() const { return data_; }
+  inline v8::Local<v8::Object> Holder() const { return info_.Holder(); }
+  inline bool IsConstructCall() const { return info_.IsConstructCall(); }
+  inline int Length() const { return info_.Length(); }
+  inline v8::Local<v8::Value> operator[](int i) const { return info_[i]; }
+  inline v8::Local<v8::Object> This() const { return info_.This(); }
+  inline v8::Isolate *GetIsolate() const { return info_.GetIsolate(); }
+
+
+ protected:
+  static const int kHolderIndex = 0;
+  static const int kIsolateIndex = 1;
+  static const int kReturnValueDefaultValueIndex = 2;
+  static const int kReturnValueIndex = 3;
+  static const int kDataIndex = 4;
+  static const int kCalleeIndex = 5;
+  static const int kContextSaveIndex = 6;
+  static const int kArgsLength = 7;
+
+ private:
+  NAN_DISALLOW_ASSIGN_COPY_MOVE(FunctionCallbackInfo)
+};
+
+template<typename T>
+class PropertyCallbackInfo {
+  const v8::PropertyCallbackInfo<T> &info_;
+  const v8::Local<v8::Value> data_;
+
+ public:
+  explicit inline PropertyCallbackInfo(
+      const v8::PropertyCallbackInfo<T> &info
+    , const v8::Local<v8::Value> data) :
+          info_(info)
+        , data_(data) {}
+
+  inline v8::Isolate* GetIsolate() const { return info_.GetIsolate(); }
+  inline v8::Local<v8::Value> Data() const { return data_; }
+  inline v8::Local<v8::Object> This() const { return info_.This(); }
+  inline v8::Local<v8::Object> Holder() const { return info_.Holder(); }
+  inline ReturnValue<T> GetReturnValue() const {
+    return ReturnValue<T>(info_.GetReturnValue());
+  }
+
+ protected:
+  static const int kHolderIndex = 0;
+  static const int kIsolateIndex = 1;
+  static const int kReturnValueDefaultValueIndex = 2;
+  static const int kReturnValueIndex = 3;
+  static const int kDataIndex = 4;
+  static const int kThisIndex = 5;
+  static const int kArgsLength = 6;
+
+ private:
+  NAN_DISALLOW_ASSIGN_COPY_MOVE(PropertyCallbackInfo)
+};
+
+namespace imp {
+static
+void FunctionCallbackWrapper(const v8::FunctionCallbackInfo<v8::Value> &info) {
+  v8::Local<v8::Object> obj = info.Data().As<v8::Object>();
+  FunctionCallback callback = reinterpret_cast<FunctionCallback>(
+      reinterpret_cast<intptr_t>(
+          obj->GetInternalField(kFunctionIndex).As<v8::External>()->Value()));
+  FunctionCallbackInfo<v8::Value>
+      cbinfo(info, obj->GetInternalField(kDataIndex));
+  callback(cbinfo);
+}
+
+typedef void (*NativeFunction)(const v8::FunctionCallbackInfo<v8::Value> &);
+
+#if NODE_MODULE_VERSION > NODE_0_12_MODULE_VERSION
+static
+void GetterCallbackWrapper(
+    v8::Local<v8::Name> property
+  , const v8::PropertyCallbackInfo<v8::Value> &info) {
+  v8::Local<v8::Object> obj = info.Data().As<v8::Object>();
+  PropertyCallbackInfo<v8::Value>
+      cbinfo(info, obj->GetInternalField(kDataIndex));
+  GetterCallback callback = reinterpret_cast<GetterCallback>(
+      reinterpret_cast<intptr_t>(
+          obj->GetInternalField(kGetterIndex).As<v8::External>()->Value()));
+  callback(property.As<v8::String>(), cbinfo);
+}
+
+typedef void (*NativeGetter)
+    (v8::Local<v8::Name>, const v8::PropertyCallbackInfo<v8::Value> &);
+
+static
+void SetterCallbackWrapper(
+    v8::Local<v8::Name> property
+  , v8::Local<v8::Value> value
+  , const v8::PropertyCallbackInfo<void> &info) {
+  v8::Local<v8::Object> obj = info.Data().As<v8::Object>();
+  PropertyCallbackInfo<void>
+      cbinfo(info, obj->GetInternalField(kDataIndex));
+  SetterCallback callback = reinterpret_cast<SetterCallback>(
+      reinterpret_cast<intptr_t>(
+          obj->GetInternalField(kSetterIndex).As<v8::External>()->Value()));
+  callback(property.As<v8::String>(), value, cbinfo);
+}
+
+typedef void (*NativeSetter)(
+    v8::Local<v8::Name>
+  , v8::Local<v8::Value>
+  , const v8::PropertyCallbackInfo<void> &);
+#else
+static
+void GetterCallbackWrapper(
+    v8::Local<v8::String> property
+  , const v8::PropertyCallbackInfo<v8::Value> &info) {
+  v8::Local<v8::Object> obj = info.Data().As<v8::Object>();
+  PropertyCallbackInfo<v8::Value>
+      cbinfo(info, obj->GetInternalField(kDataIndex));
+  GetterCallback callback = reinterpret_cast<GetterCallback>(
+      reinterpret_cast<intptr_t>(
+          obj->GetInternalField(kGetterIndex).As<v8::External>()->Value()));
+  callback(property, cbinfo);
+}
+
+typedef void (*NativeGetter)
+    (v8::Local<v8::String>, const v8::PropertyCallbackInfo<v8::Value> &);
+
+static
+void SetterCallbackWrapper(
+    v8::Local<v8::String> property
+  , v8::Local<v8::Value> value
+  , const v8::PropertyCallbackInfo<void> &info) {
+  v8::Local<v8::Object> obj = info.Data().As<v8::Object>();
+  PropertyCallbackInfo<void>
+      cbinfo(info, obj->GetInternalField(kDataIndex));
+  SetterCallback callback = reinterpret_cast<SetterCallback>(
+      reinterpret_cast<intptr_t>(
+          obj->GetInternalField(kSetterIndex).As<v8::External>()->Value()));
+  callback(property, value, cbinfo);
+}
+
+typedef void (*NativeSetter)(
+    v8::Local<v8::String>
+  , v8::Local<v8::Value>
+  , const v8::PropertyCallbackInfo<void> &);
+#endif
+
+#if NODE_MODULE_VERSION > NODE_0_12_MODULE_VERSION
+static
+void PropertyGetterCallbackWrapper(
+    v8::Local<v8::Name> property
+  , const v8::PropertyCallbackInfo<v8::Value> &info) {
+  v8::Local<v8::Object> obj = info.Data().As<v8::Object>();
+  PropertyCallbackInfo<v8::Value>
+      cbinfo(info, obj->GetInternalField(kDataIndex));
+  PropertyGetterCallback callback = reinterpret_cast<PropertyGetterCallback>(
+      reinterpret_cast<intptr_t>(
+          obj->GetInternalField(kPropertyGetterIndex)
+              .As<v8::External>()->Value()));
+  callback(property.As<v8::String>(), cbinfo);
+}
+
+typedef void (*NativePropertyGetter)
+    (v8::Local<v8::Name>, const v8::PropertyCallbackInfo<v8::Value> &);
+
+static
+void PropertySetterCallbackWrapper(
+    v8::Local<v8::Name> property
+  , v8::Local<v8::Value> value
+  , const v8::PropertyCallbackInfo<v8::Value> &info) {
+  v8::Local<v8::Object> obj = info.Data().As<v8::Object>();
+  PropertyCallbackInfo<v8::Value>
+      cbinfo(info, obj->GetInternalField(kDataIndex));
+  PropertySetterCallback callback = reinterpret_cast<PropertySetterCallback>(
+      reinterpret_cast<intptr_t>(
+          obj->GetInternalField(kPropertySetterIndex)
+              .As<v8::External>()->Value()));
+  callback(property.As<v8::String>(), value, cbinfo);
+}
+
+typedef void (*NativePropertySetter)(
+    v8::Local<v8::Name>
+  , v8::Local<v8::Value>
+  , const v8::PropertyCallbackInfo<v8::Value> &);
+
+static
+void PropertyEnumeratorCallbackWrapper(
+    const v8::PropertyCallbackInfo<v8::Array> &info) {
+  v8::Local<v8::Object> obj = info.Data().As<v8::Object>();
+  PropertyCallbackInfo<v8::Array>
+      cbinfo(info, obj->GetInternalField(kDataIndex));
+  PropertyEnumeratorCallback callback =
+      reinterpret_cast<PropertyEnumeratorCallback>(reinterpret_cast<intptr_t>(
+          obj->GetInternalField(kPropertyEnumeratorIndex)
+              .As<v8::External>()->Value()));
+  callback(cbinfo);
+}
+
+typedef void (*NativePropertyEnumerator)
+    (const v8::PropertyCallbackInfo<v8::Array> &);
+
+static
+void PropertyDeleterCallbackWrapper(
+    v8::Local<v8::Name> property
+  , const v8::PropertyCallbackInfo<v8::Boolean> &info) {
+  v8::Local<v8::Object> obj = info.Data().As<v8::Object>();
+  PropertyCallbackInfo<v8::Boolean>
+      cbinfo(info, obj->GetInternalField(kDataIndex));
+  PropertyDeleterCallback callback = reinterpret_cast<PropertyDeleterCallback>(
+      reinterpret_cast<intptr_t>(
+          obj->GetInternalField(kPropertyDeleterIndex)
+              .As<v8::External>()->Value()));
+  callback(property.As<v8::String>(), cbinfo);
+}
+
+typedef void (NativePropertyDeleter)
+    (v8::Local<v8::Name>, const v8::PropertyCallbackInfo<v8::Boolean> &);
+
+static
+void PropertyQueryCallbackWrapper(
+    v8::Local<v8::Name> property
+  , const v8::PropertyCallbackInfo<v8::Integer> &info) {
+  v8::Local<v8::Object> obj = info.Data().As<v8::Object>();
+  PropertyCallbackInfo<v8::Integer>
+      cbinfo(info, obj->GetInternalField(kDataIndex));
+  PropertyQueryCallback callback = reinterpret_cast<PropertyQueryCallback>(
+      reinterpret_cast<intptr_t>(
+          obj->GetInternalField(kPropertyQueryIndex)
+              .As<v8::External>()->Value()));
+  callback(property.As<v8::String>(), cbinfo);
+}
+
+typedef void (*NativePropertyQuery)
+    (v8::Local<v8::Name>, const v8::PropertyCallbackInfo<v8::Integer> &);
+#else
+static
+void PropertyGetterCallbackWrapper(
+    v8::Local<v8::String> property
+  , const v8::PropertyCallbackInfo<v8::Value> &info) {
+  v8::Local<v8::Object> obj = info.Data().As<v8::Object>();
+  PropertyCallbackInfo<v8::Value>
+      cbinfo(info, obj->GetInternalField(kDataIndex));
+  PropertyGetterCallback callback = reinterpret_cast<PropertyGetterCallback>(
+      reinterpret_cast<intptr_t>(
+          obj->GetInternalField(kPropertyGetterIndex)
+              .As<v8::External>()->Value()));
+  callback(property, cbinfo);
+}
+
+typedef void (*NativePropertyGetter)
+    (v8::Local<v8::String>, const v8::PropertyCallbackInfo<v8::Value> &);
+
+static
+void PropertySetterCallbackWrapper(
+    v8::Local<v8::String> property
+  , v8::Local<v8::Value> value
+  , const v8::PropertyCallbackInfo<v8::Value> &info) {
+  v8::Local<v8::Object> obj = info.Data().As<v8::Object>();
+  PropertyCallbackInfo<v8::Value>
+      cbinfo(info, obj->GetInternalField(kDataIndex));
+  PropertySetterCallback callback = reinterpret_cast<PropertySetterCallback>(
+      reinterpret_cast<intptr_t>(
+          obj->GetInternalField(kPropertySetterIndex)
+              .As<v8::External>()->Value()));
+  callback(property, value, cbinfo);
+}
+
+typedef void (*NativePropertySetter)(
+    v8::Local<v8::String>
+  , v8::Local<v8::Value>
+  , const v8::PropertyCallbackInfo<v8::Value> &);
+
+static
+void PropertyEnumeratorCallbackWrapper(
+    const v8::PropertyCallbackInfo<v8::Array> &info) {
+  v8::Local<v8::Object> obj = info.Data().As<v8::Object>();
+  PropertyCallbackInfo<v8::Array>
+      cbinfo(info, obj->GetInternalField(kDataIndex));
+  PropertyEnumeratorCallback callback =
+      reinterpret_cast<PropertyEnumeratorCallback>(reinterpret_cast<intptr_t>(
+          obj->GetInternalField(kPropertyEnumeratorIndex)
+              .As<v8::External>()->Value()));
+  callback(cbinfo);
+}
+
+typedef void (*NativePropertyEnumerator)
+    (const v8::PropertyCallbackInfo<v8::Array> &);
+
+static
+void PropertyDeleterCallbackWrapper(
+    v8::Local<v8::String> property
+  , const v8::PropertyCallbackInfo<v8::Boolean> &info) {
+  v8::Local<v8::Object> obj = info.Data().As<v8::Object>();
+  PropertyCallbackInfo<v8::Boolean>
+      cbinfo(info, obj->GetInternalField(kDataIndex));
+  PropertyDeleterCallback callback = reinterpret_cast<PropertyDeleterCallback>(
+      reinterpret_cast<intptr_t>(
+          obj->GetInternalField(kPropertyDeleterIndex)
+              .As<v8::External>()->Value()));
+  callback(property, cbinfo);
+}
+
+typedef void (NativePropertyDeleter)
+    (v8::Local<v8::String>, const v8::PropertyCallbackInfo<v8::Boolean> &);
+
+static
+void PropertyQueryCallbackWrapper(
+    v8::Local<v8::String> property
+  , const v8::PropertyCallbackInfo<v8::Integer> &info) {
+  v8::Local<v8::Object> obj = info.Data().As<v8::Object>();
+  PropertyCallbackInfo<v8::Integer>
+      cbinfo(info, obj->GetInternalField(kDataIndex));
+  PropertyQueryCallback callback = reinterpret_cast<PropertyQueryCallback>(
+      reinterpret_cast<intptr_t>(
+          obj->GetInternalField(kPropertyQueryIndex)
+              .As<v8::External>()->Value()));
+  callback(property, cbinfo);
+}
+
+typedef void (*NativePropertyQuery)
+    (v8::Local<v8::String>, const v8::PropertyCallbackInfo<v8::Integer> &);
+#endif
+
+static
+void IndexGetterCallbackWrapper(
+    uint32_t index, const v8::PropertyCallbackInfo<v8::Value> &info) {
+  v8::Local<v8::Object> obj = info.Data().As<v8::Object>();
+  PropertyCallbackInfo<v8::Value>
+      cbinfo(info, obj->GetInternalField(kDataIndex));
+  IndexGetterCallback callback = reinterpret_cast<IndexGetterCallback>(
+      reinterpret_cast<intptr_t>(
+          obj->GetInternalField(kIndexPropertyGetterIndex)
+              .As<v8::External>()->Value()));
+  callback(index, cbinfo);
+}
+
+typedef void (*NativeIndexGetter)
+    (uint32_t, const v8::PropertyCallbackInfo<v8::Value> &);
+
+static
+void IndexSetterCallbackWrapper(
+    uint32_t index
+  , v8::Local<v8::Value> value
+  , const v8::PropertyCallbackInfo<v8::Value> &info) {
+  v8::Local<v8::Object> obj = info.Data().As<v8::Object>();
+  PropertyCallbackInfo<v8::Value>
+      cbinfo(info, obj->GetInternalField(kDataIndex));
+  IndexSetterCallback callback = reinterpret_cast<IndexSetterCallback>(
+      reinterpret_cast<intptr_t>(
+          obj->GetInternalField(kIndexPropertySetterIndex)
+              .As<v8::External>()->Value()));
+  callback(index, value, cbinfo);
+}
+
+typedef void (*NativeIndexSetter)(
+    uint32_t
+  , v8::Local<v8::Value>
+  , const v8::PropertyCallbackInfo<v8::Value> &);
+
+static
+void IndexEnumeratorCallbackWrapper(
+    const v8::PropertyCallbackInfo<v8::Array> &info) {
+  v8::Local<v8::Object> obj = info.Data().As<v8::Object>();
+  PropertyCallbackInfo<v8::Array>
+      cbinfo(info, obj->GetInternalField(kDataIndex));
+  IndexEnumeratorCallback callback = reinterpret_cast<IndexEnumeratorCallback>(
+      reinterpret_cast<intptr_t>(
+          obj->GetInternalField(
+              kIndexPropertyEnumeratorIndex).As<v8::External>()->Value()));
+  callback(cbinfo);
+}
+
+typedef void (*NativeIndexEnumerator)
+    (const v8::PropertyCallbackInfo<v8::Array> &);
+
+static
+void IndexDeleterCallbackWrapper(
+    uint32_t index, const v8::PropertyCallbackInfo<v8::Boolean> &info) {
+  v8::Local<v8::Object> obj = info.Data().As<v8::Object>();
+  PropertyCallbackInfo<v8::Boolean>
+      cbinfo(info, obj->GetInternalField(kDataIndex));
+  IndexDeleterCallback callback = reinterpret_cast<IndexDeleterCallback>(
+      reinterpret_cast<intptr_t>(
+          obj->GetInternalField(kIndexPropertyDeleterIndex)
+              .As<v8::External>()->Value()));
+  callback(index, cbinfo);
+}
+
+typedef void (*NativeIndexDeleter)
+    (uint32_t, const v8::PropertyCallbackInfo<v8::Boolean> &);
+
+static
+void IndexQueryCallbackWrapper(
+    uint32_t index, const v8::PropertyCallbackInfo<v8::Integer> &info) {
+  v8::Local<v8::Object> obj = info.Data().As<v8::Object>();
+  PropertyCallbackInfo<v8::Integer>
+      cbinfo(info, obj->GetInternalField(kDataIndex));
+  IndexQueryCallback callback = reinterpret_cast<IndexQueryCallback>(
+      reinterpret_cast<intptr_t>(
+          obj->GetInternalField(kIndexPropertyQueryIndex)
+              .As<v8::External>()->Value()));
+  callback(index, cbinfo);
+}
+
+typedef void (*NativeIndexQuery)
+    (uint32_t, const v8::PropertyCallbackInfo<v8::Integer> &);
+}  // end of namespace imp
+
+#endif  // NAN_CALLBACKS_12_INL_H_

--- a/deps/nan/nan_callbacks_pre_12_inl.h
+++ b/deps/nan/nan_callbacks_pre_12_inl.h
@@ -1,0 +1,506 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2015 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+#ifndef NAN_CALLBACKS_PRE_12_INL_H_
+#define NAN_CALLBACKS_PRE_12_INL_H_
+
+namespace imp {
+template<typename T> class ReturnValueImp;
+}  // end of namespace imp
+
+template<typename T>
+class ReturnValue {
+  v8::Isolate *isolate_;
+  v8::Persistent<T> *value_;
+  friend class imp::ReturnValueImp<T>;
+
+ public:
+  template <class S>
+  explicit inline ReturnValue(v8::Isolate *isolate, v8::Persistent<S> *p) :
+      isolate_(isolate), value_(p) {}
+  template <class S>
+  explicit inline ReturnValue(const ReturnValue<S>& that)
+      : isolate_(that.isolate_), value_(that.value_) {
+    TYPE_CHECK(T, S);
+  }
+
+  // Handle setters
+  template <typename S> inline void Set(const v8::Local<S> &handle) {
+    TYPE_CHECK(T, S);
+    value_->Dispose();
+    *value_ = v8::Persistent<T>::New(handle);
+  }
+
+  template <typename S> inline void Set(const Global<S> &handle) {
+    TYPE_CHECK(T, S);
+    value_->Dispose();
+    *value_ = v8::Persistent<T>::New(handle.persistent);
+    const_cast<Global<S> &>(handle).Reset();
+  }
+
+  // Fast primitive setters
+  inline void Set(bool value) {
+    TYPE_CHECK(T, v8::Boolean);
+    value_->Dispose();
+    *value_ = v8::Persistent<T>::New(v8::Boolean::New(value));
+  }
+
+  inline void Set(double i) {
+    TYPE_CHECK(T, v8::Number);
+    value_->Dispose();
+    *value_ = v8::Persistent<T>::New(v8::Number::New(i));
+  }
+
+  inline void Set(int32_t i) {
+    TYPE_CHECK(T, v8::Integer);
+    value_->Dispose();
+    *value_ = v8::Persistent<T>::New(v8::Int32::New(i));
+  }
+
+  inline void Set(uint32_t i) {
+    TYPE_CHECK(T, v8::Integer);
+    value_->Dispose();
+    *value_ = v8::Persistent<T>::New(v8::Uint32::New(i));
+  }
+
+  // Fast JS primitive setters
+  inline void SetNull() {
+    TYPE_CHECK(T, v8::Primitive);
+    value_->Dispose();
+    *value_ = v8::Persistent<T>::New(v8::Null());
+  }
+
+  inline void SetUndefined() {
+    TYPE_CHECK(T, v8::Primitive);
+    value_->Dispose();
+    *value_ = v8::Persistent<T>::New(v8::Undefined());
+  }
+
+  inline void SetEmptyString() {
+    TYPE_CHECK(T, v8::String);
+    value_->Dispose();
+    *value_ = v8::Persistent<T>::New(v8::String::Empty());
+  }
+
+  // Convenience getter for isolate
+  inline v8::Isolate *GetIsolate() const {
+    return isolate_;
+  }
+
+  // Pointer setter: Uncompilable to prevent inadvertent misuse.
+  template<typename S>
+  inline void Set(S *whatever) { TYPE_CHECK(S*, v8::Primitive); }
+};
+
+template<typename T>
+class FunctionCallbackInfo {
+  const v8::Arguments &args_;
+  v8::Local<v8::Value> data_;
+  ReturnValue<T> return_value_;
+  v8::Persistent<T> retval_;
+
+ public:
+  explicit inline FunctionCallbackInfo(
+      const v8::Arguments &args
+    , v8::Local<v8::Value> data) :
+          args_(args)
+        , data_(data)
+        , return_value_(args.GetIsolate(), &retval_)
+        , retval_(v8::Persistent<T>::New(v8::Undefined())) {}
+
+  inline ~FunctionCallbackInfo() {
+    retval_.Dispose();
+    retval_.Clear();
+  }
+
+  inline ReturnValue<T> GetReturnValue() const {
+    return ReturnValue<T>(return_value_);
+  }
+
+  inline v8::Local<v8::Function> Callee() const { return args_.Callee(); }
+  inline v8::Local<v8::Value> Data() const { return data_; }
+  inline v8::Local<v8::Object> Holder() const { return args_.Holder(); }
+  inline bool IsConstructCall() const { return args_.IsConstructCall(); }
+  inline int Length() const { return args_.Length(); }
+  inline v8::Local<v8::Value> operator[](int i) const { return args_[i]; }
+  inline v8::Local<v8::Object> This() const { return args_.This(); }
+  inline v8::Isolate *GetIsolate() const { return args_.GetIsolate(); }
+
+
+ protected:
+  static const int kHolderIndex = 0;
+  static const int kIsolateIndex = 1;
+  static const int kReturnValueDefaultValueIndex = 2;
+  static const int kReturnValueIndex = 3;
+  static const int kDataIndex = 4;
+  static const int kCalleeIndex = 5;
+  static const int kContextSaveIndex = 6;
+  static const int kArgsLength = 7;
+
+ private:
+  NAN_DISALLOW_ASSIGN_COPY_MOVE(FunctionCallbackInfo)
+};
+
+template<typename T>
+class PropertyCallbackInfoBase {
+  const v8::AccessorInfo &info_;
+  const v8::Local<v8::Value> data_;
+
+ public:
+  explicit inline PropertyCallbackInfoBase(
+      const v8::AccessorInfo &info
+    , const v8::Local<v8::Value> data) :
+          info_(info)
+        , data_(data) {}
+
+  inline v8::Isolate* GetIsolate() const { return info_.GetIsolate(); }
+  inline v8::Local<v8::Value> Data() const { return data_; }
+  inline v8::Local<v8::Object> This() const { return info_.This(); }
+  inline v8::Local<v8::Object> Holder() const { return info_.Holder(); }
+
+ protected:
+  static const int kHolderIndex = 0;
+  static const int kIsolateIndex = 1;
+  static const int kReturnValueDefaultValueIndex = 2;
+  static const int kReturnValueIndex = 3;
+  static const int kDataIndex = 4;
+  static const int kThisIndex = 5;
+  static const int kArgsLength = 6;
+
+ private:
+  NAN_DISALLOW_ASSIGN_COPY_MOVE(PropertyCallbackInfoBase)
+};
+
+template<typename T>
+class PropertyCallbackInfo : public PropertyCallbackInfoBase<T> {
+  ReturnValue<T> return_value_;
+  v8::Persistent<T> retval_;
+
+ public:
+  explicit inline PropertyCallbackInfo(
+      const v8::AccessorInfo &info
+    , const v8::Local<v8::Value> data) :
+          PropertyCallbackInfoBase<T>(info, data)
+        , return_value_(info.GetIsolate(), &retval_)
+        , retval_(v8::Persistent<T>::New(v8::Undefined())) {}
+
+  inline ~PropertyCallbackInfo() {
+    retval_.Dispose();
+    retval_.Clear();
+  }
+
+  inline ReturnValue<T> GetReturnValue() const { return return_value_; }
+};
+
+template<>
+class PropertyCallbackInfo<v8::Array> :
+    public PropertyCallbackInfoBase<v8::Array> {
+  ReturnValue<v8::Array> return_value_;
+  v8::Persistent<v8::Array> retval_;
+
+ public:
+  explicit inline PropertyCallbackInfo(
+      const v8::AccessorInfo &info
+    , const v8::Local<v8::Value> data) :
+          PropertyCallbackInfoBase<v8::Array>(info, data)
+        , return_value_(info.GetIsolate(), &retval_)
+        , retval_(v8::Persistent<v8::Array>::New(v8::Local<v8::Array>())) {}
+
+  inline ~PropertyCallbackInfo() {
+    retval_.Dispose();
+    retval_.Clear();
+  }
+
+  inline ReturnValue<v8::Array> GetReturnValue() const {
+    return return_value_;
+  }
+};
+
+template<>
+class PropertyCallbackInfo<v8::Boolean> :
+    public PropertyCallbackInfoBase<v8::Boolean> {
+  ReturnValue<v8::Boolean> return_value_;
+  v8::Persistent<v8::Boolean> retval_;
+
+ public:
+  explicit inline PropertyCallbackInfo(
+      const v8::AccessorInfo &info
+    , const v8::Local<v8::Value> data) :
+          PropertyCallbackInfoBase<v8::Boolean>(info, data)
+        , return_value_(info.GetIsolate(), &retval_)
+        , retval_(v8::Persistent<v8::Boolean>::New(v8::Local<v8::Boolean>())) {}
+
+  inline ~PropertyCallbackInfo() {
+    retval_.Dispose();
+    retval_.Clear();
+  }
+
+  inline ReturnValue<v8::Boolean> GetReturnValue() const {
+    return return_value_;
+  }
+};
+
+template<>
+class PropertyCallbackInfo<v8::Integer> :
+    public PropertyCallbackInfoBase<v8::Integer> {
+  ReturnValue<v8::Integer> return_value_;
+  v8::Persistent<v8::Integer> retval_;
+
+ public:
+  explicit inline PropertyCallbackInfo(
+      const v8::AccessorInfo &info
+    , const v8::Local<v8::Value> data) :
+          PropertyCallbackInfoBase<v8::Integer>(info, data)
+        , return_value_(info.GetIsolate(), &retval_)
+        , retval_(v8::Persistent<v8::Integer>::New(v8::Local<v8::Integer>())) {}
+
+  inline ~PropertyCallbackInfo() {
+    retval_.Dispose();
+    retval_.Clear();
+  }
+
+  inline ReturnValue<v8::Integer> GetReturnValue() const {
+    return return_value_;
+  }
+};
+
+namespace imp {
+template<typename T>
+class ReturnValueImp : public ReturnValue<T> {
+ public:
+  explicit ReturnValueImp(ReturnValue<T> that) :
+      ReturnValue<T>(that) {}
+  NAN_INLINE v8::Handle<T> Value() {
+      return *ReturnValue<T>::value_;
+  }
+};
+
+static
+v8::Handle<v8::Value> FunctionCallbackWrapper(const v8::Arguments &args) {
+  v8::Local<v8::Object> obj = args.Data().As<v8::Object>();
+  FunctionCallback callback = reinterpret_cast<FunctionCallback>(
+      reinterpret_cast<intptr_t>(
+          obj->GetInternalField(kFunctionIndex).As<v8::External>()->Value()));
+  FunctionCallbackInfo<v8::Value>
+      cbinfo(args, obj->GetInternalField(kDataIndex));
+  callback(cbinfo);
+  return ReturnValueImp<v8::Value>(cbinfo.GetReturnValue()).Value();
+}
+
+typedef v8::Handle<v8::Value> (*NativeFunction)(const v8::Arguments &);
+
+static
+v8::Handle<v8::Value> GetterCallbackWrapper(
+    v8::Local<v8::String> property, const v8::AccessorInfo &info) {
+  v8::Local<v8::Object> obj = info.Data().As<v8::Object>();
+  PropertyCallbackInfo<v8::Value>
+      cbinfo(info, obj->GetInternalField(kDataIndex));
+  GetterCallback callback = reinterpret_cast<GetterCallback>(
+      reinterpret_cast<intptr_t>(
+          obj->GetInternalField(kGetterIndex).As<v8::External>()->Value()));
+  callback(property, cbinfo);
+  return ReturnValueImp<v8::Value>(cbinfo.GetReturnValue()).Value();
+}
+
+typedef v8::Handle<v8::Value> (*NativeGetter)
+    (v8::Local<v8::String>, const v8::AccessorInfo &);
+
+static
+void SetterCallbackWrapper(
+    v8::Local<v8::String> property
+  , v8::Local<v8::Value> value
+  , const v8::AccessorInfo &info) {
+  v8::Local<v8::Object> obj = info.Data().As<v8::Object>();
+  PropertyCallbackInfo<void>
+      cbinfo(info, obj->GetInternalField(kDataIndex));
+  SetterCallback callback = reinterpret_cast<SetterCallback>(
+      reinterpret_cast<intptr_t>(
+          obj->GetInternalField(kSetterIndex).As<v8::External>()->Value()));
+  callback(property, value, cbinfo);
+}
+
+typedef void (*NativeSetter)
+    (v8::Local<v8::String>, v8::Local<v8::Value>, const v8::AccessorInfo &);
+
+static
+v8::Handle<v8::Value> PropertyGetterCallbackWrapper(
+    v8::Local<v8::String> property, const v8::AccessorInfo &info) {
+  v8::Local<v8::Object> obj = info.Data().As<v8::Object>();
+  PropertyCallbackInfo<v8::Value>
+      cbinfo(info, obj->GetInternalField(kDataIndex));
+  PropertyGetterCallback callback = reinterpret_cast<PropertyGetterCallback>(
+      reinterpret_cast<intptr_t>(
+          obj->GetInternalField(kPropertyGetterIndex)
+              .As<v8::External>()->Value()));
+  callback(property, cbinfo);
+  return ReturnValueImp<v8::Value>(cbinfo.GetReturnValue()).Value();
+}
+
+typedef v8::Handle<v8::Value> (*NativePropertyGetter)
+    (v8::Local<v8::String>, const v8::AccessorInfo &);
+
+static
+v8::Handle<v8::Value> PropertySetterCallbackWrapper(
+    v8::Local<v8::String> property
+  , v8::Local<v8::Value> value
+  , const v8::AccessorInfo &info) {
+  v8::Local<v8::Object> obj = info.Data().As<v8::Object>();
+  PropertyCallbackInfo<v8::Value>
+      cbinfo(info, obj->GetInternalField(kDataIndex));
+  PropertySetterCallback callback = reinterpret_cast<PropertySetterCallback>(
+      reinterpret_cast<intptr_t>(
+          obj->GetInternalField(kPropertySetterIndex)
+              .As<v8::External>()->Value()));
+  callback(property, value, cbinfo);
+  return ReturnValueImp<v8::Value>(cbinfo.GetReturnValue()).Value();
+}
+
+typedef v8::Handle<v8::Value> (*NativePropertySetter)
+    (v8::Local<v8::String>, v8::Local<v8::Value>, const v8::AccessorInfo &);
+
+static
+v8::Handle<v8::Array> PropertyEnumeratorCallbackWrapper(
+    const v8::AccessorInfo &info) {
+  v8::Local<v8::Object> obj = info.Data().As<v8::Object>();
+  PropertyCallbackInfo<v8::Array>
+      cbinfo(info, obj->GetInternalField(kDataIndex));
+  PropertyEnumeratorCallback callback =
+      reinterpret_cast<PropertyEnumeratorCallback>(reinterpret_cast<intptr_t>(
+          obj->GetInternalField(kPropertyEnumeratorIndex)
+              .As<v8::External>()->Value()));
+  callback(cbinfo);
+  return ReturnValueImp<v8::Array>(cbinfo.GetReturnValue()).Value();
+}
+
+typedef v8::Handle<v8::Array> (*NativePropertyEnumerator)
+    (const v8::AccessorInfo &);
+
+static
+v8::Handle<v8::Boolean> PropertyDeleterCallbackWrapper(
+    v8::Local<v8::String> property
+  , const v8::AccessorInfo &info) {
+  v8::Local<v8::Object> obj = info.Data().As<v8::Object>();
+  PropertyCallbackInfo<v8::Boolean>
+      cbinfo(info, obj->GetInternalField(kDataIndex));
+  PropertyDeleterCallback callback = reinterpret_cast<PropertyDeleterCallback>(
+      reinterpret_cast<intptr_t>(
+          obj->GetInternalField(kPropertyDeleterIndex)
+              .As<v8::External>()->Value()));
+  callback(property, cbinfo);
+  return ReturnValueImp<v8::Boolean>(cbinfo.GetReturnValue()).Value();
+}
+
+typedef v8::Handle<v8::Boolean> (NativePropertyDeleter)
+    (v8::Local<v8::String>, const v8::AccessorInfo &);
+
+static
+v8::Handle<v8::Integer> PropertyQueryCallbackWrapper(
+    v8::Local<v8::String> property, const v8::AccessorInfo &info) {
+  v8::Local<v8::Object> obj = info.Data().As<v8::Object>();
+  PropertyCallbackInfo<v8::Integer>
+      cbinfo(info, obj->GetInternalField(kDataIndex));
+  PropertyQueryCallback callback = reinterpret_cast<PropertyQueryCallback>(
+      reinterpret_cast<intptr_t>(
+          obj->GetInternalField(kPropertyQueryIndex)
+              .As<v8::External>()->Value()));
+  callback(property, cbinfo);
+  return ReturnValueImp<v8::Integer>(cbinfo.GetReturnValue()).Value();
+}
+
+typedef v8::Handle<v8::Integer> (*NativePropertyQuery)
+    (v8::Local<v8::String>, const v8::AccessorInfo &);
+
+static
+v8::Handle<v8::Value> IndexGetterCallbackWrapper(
+    uint32_t index, const v8::AccessorInfo &info) {
+  v8::Local<v8::Object> obj = info.Data().As<v8::Object>();
+  PropertyCallbackInfo<v8::Value>
+      cbinfo(info, obj->GetInternalField(kDataIndex));
+  IndexGetterCallback callback = reinterpret_cast<IndexGetterCallback>(
+      reinterpret_cast<intptr_t>(
+          obj->GetInternalField(kIndexPropertyGetterIndex)
+              .As<v8::External>()->Value()));
+  callback(index, cbinfo);
+  return ReturnValueImp<v8::Value>(cbinfo.GetReturnValue()).Value();
+}
+
+typedef v8::Handle<v8::Value> (*NativeIndexGetter)
+    (uint32_t, const v8::AccessorInfo &);
+
+static
+v8::Handle<v8::Value> IndexSetterCallbackWrapper(
+    uint32_t index
+  , v8::Local<v8::Value> value
+  , const v8::AccessorInfo &info) {
+  v8::Local<v8::Object> obj = info.Data().As<v8::Object>();
+  PropertyCallbackInfo<v8::Value>
+      cbinfo(info, obj->GetInternalField(kDataIndex));
+  IndexSetterCallback callback = reinterpret_cast<IndexSetterCallback>(
+      reinterpret_cast<intptr_t>(
+          obj->GetInternalField(kIndexPropertySetterIndex)
+              .As<v8::External>()->Value()));
+  callback(index, value, cbinfo);
+  return ReturnValueImp<v8::Value>(cbinfo.GetReturnValue()).Value();
+}
+
+typedef v8::Handle<v8::Value> (*NativeIndexSetter)
+    (uint32_t, v8::Local<v8::Value>, const v8::AccessorInfo &);
+
+static
+v8::Handle<v8::Array> IndexEnumeratorCallbackWrapper(
+    const v8::AccessorInfo &info) {
+  v8::Local<v8::Object> obj = info.Data().As<v8::Object>();
+  PropertyCallbackInfo<v8::Array>
+      cbinfo(info, obj->GetInternalField(kDataIndex));
+  IndexEnumeratorCallback callback = reinterpret_cast<IndexEnumeratorCallback>(
+      reinterpret_cast<intptr_t>(
+          obj->GetInternalField(kIndexPropertyEnumeratorIndex)
+              .As<v8::External>()->Value()));
+  callback(cbinfo);
+  return ReturnValueImp<v8::Array>(cbinfo.GetReturnValue()).Value();
+}
+
+typedef v8::Handle<v8::Array> (*NativeIndexEnumerator)
+    (const v8::AccessorInfo &);
+
+static
+v8::Handle<v8::Boolean> IndexDeleterCallbackWrapper(
+    uint32_t index, const v8::AccessorInfo &info) {
+  v8::Local<v8::Object> obj = info.Data().As<v8::Object>();
+  PropertyCallbackInfo<v8::Boolean>
+      cbinfo(info, obj->GetInternalField(kDataIndex));
+  IndexDeleterCallback callback = reinterpret_cast<IndexDeleterCallback>(
+      reinterpret_cast<intptr_t>(
+          obj->GetInternalField(kIndexPropertyDeleterIndex)
+              .As<v8::External>()->Value()));
+  callback(index, cbinfo);
+  return ReturnValueImp<v8::Boolean>(cbinfo.GetReturnValue()).Value();
+}
+
+typedef v8::Handle<v8::Boolean> (*NativeIndexDeleter)
+    (uint32_t, const v8::AccessorInfo &);
+
+static
+v8::Handle<v8::Integer> IndexQueryCallbackWrapper(
+    uint32_t index, const v8::AccessorInfo &info) {
+  v8::Local<v8::Object> obj = info.Data().As<v8::Object>();
+  PropertyCallbackInfo<v8::Integer>
+      cbinfo(info, obj->GetInternalField(kDataIndex));
+  IndexQueryCallback callback = reinterpret_cast<IndexQueryCallback>(
+      reinterpret_cast<intptr_t>(
+          obj->GetInternalField(kIndexPropertyQueryIndex)
+              .As<v8::External>()->Value()));
+  callback(index, cbinfo);
+  return ReturnValueImp<v8::Integer>(cbinfo.GetReturnValue()).Value();
+}
+
+typedef v8::Handle<v8::Integer> (*NativeIndexQuery)
+    (uint32_t, const v8::AccessorInfo &);
+}  // end of namespace imp
+
+#endif  // NAN_CALLBACKS_PRE_12_INL_H_

--- a/deps/nan/nan_converters.h
+++ b/deps/nan/nan_converters.h
@@ -1,0 +1,64 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2015 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+#ifndef NAN_CONVERTERS_H_
+#define NAN_CONVERTERS_H_
+
+namespace imp {
+template<typename T> struct ToFactoryBase {
+  typedef MaybeLocal<T> return_t;
+};
+template<typename T> struct ValueFactoryBase { typedef Maybe<T> return_t; };
+
+template<typename T> struct ToFactory;
+
+#define X(TYPE)                                                                \
+    template<>                                                                 \
+    struct ToFactory<v8::TYPE> : ToFactoryBase<v8::TYPE> {                     \
+      static inline return_t convert(v8::Local<v8::Value> val);                \
+    };
+
+X(Boolean)
+X(Number)
+X(String)
+X(Object)
+X(Integer)
+X(Uint32)
+X(Int32)
+
+#undef X
+
+#define X(TYPE)                                                                \
+    template<>                                                                 \
+    struct ToFactory<TYPE> : ValueFactoryBase<TYPE> {                          \
+      static inline return_t convert(v8::Local<v8::Value> val);                \
+    };
+
+X(bool)
+X(double)
+X(int64_t)
+X(uint32_t)
+X(int32_t)
+
+#undef X
+}  // end of namespace imp
+
+template<typename T>
+NAN_INLINE
+typename imp::ToFactory<T>::return_t To(v8::Local<v8::Value> val) {
+  return imp::ToFactory<T>::convert(val);
+}
+
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
+  (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
+# include "nan_converters_43_inl.h"
+#else
+# include "nan_converters_pre_43_inl.h"
+#endif
+
+#endif  // NAN_CONVERTERS_H_

--- a/deps/nan/nan_converters_43_inl.h
+++ b/deps/nan/nan_converters_43_inl.h
@@ -1,0 +1,42 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2015 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+#ifndef NAN_CONVERTERS_43_INL_H_
+#define NAN_CONVERTERS_43_INL_H_
+
+#define X(TYPE)                                                                \
+imp::ToFactory<v8::TYPE>::return_t                                             \
+imp::ToFactory<v8::TYPE>::convert(v8::Local<v8::Value> val) {                  \
+  return val->To ## TYPE(GetCurrentContext());                                 \
+}
+
+X(Boolean)
+X(Number)
+X(String)
+X(Object)
+X(Integer)
+X(Uint32)
+X(Int32)
+
+#undef X
+
+#define X(TYPE, NAME)                                                          \
+imp::ToFactory<TYPE>::return_t                                                 \
+imp::ToFactory<TYPE>::convert(v8::Local<v8::Value> val) {                      \
+  return val->NAME ## Value(GetCurrentContext());                              \
+}
+
+X(bool, Boolean)
+X(double, Number)
+X(int64_t, Integer)
+X(uint32_t, Uint32)
+X(int32_t, Int32)
+
+#undef X
+
+#endif  // NAN_CONVERTERS_43_INL_H_

--- a/deps/nan/nan_converters_pre_43_inl.h
+++ b/deps/nan/nan_converters_pre_43_inl.h
@@ -1,0 +1,42 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2015 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+#ifndef NAN_CONVERTERS_PRE_43_INL_H_
+#define NAN_CONVERTERS_PRE_43_INL_H_
+
+#define X(TYPE)                                                                \
+imp::ToFactory<v8::TYPE>::return_t                                             \
+imp::ToFactory<v8::TYPE>::convert(v8::Local<v8::Value> val) {                  \
+  return MaybeLocal<v8::TYPE>(val->To ## TYPE());                              \
+}
+
+X(Boolean)
+X(Number)
+X(String)
+X(Object)
+X(Integer)
+X(Uint32)
+X(Int32)
+
+#undef X
+
+#define X(TYPE, NAME)                                                          \
+imp::ToFactory<TYPE>::return_t                                                 \
+imp::ToFactory<TYPE>::convert(v8::Local<v8::Value> val) {                      \
+  return Just<TYPE>(val->NAME ##Value());                                      \
+}
+
+X(bool, Boolean)
+X(double, Number)
+X(int64_t, Integer)
+X(uint32_t, Uint32)
+X(int32_t, Int32)
+
+#undef X
+
+#endif  // NAN_CONVERTERS_PRE_43_INL_H_

--- a/deps/nan/nan_implementation_12_inl.h
+++ b/deps/nan/nan_implementation_12_inl.h
@@ -1,0 +1,404 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2015 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+#ifndef NAN_IMPLEMENTATION_12_INL_H_
+#define NAN_IMPLEMENTATION_12_INL_H_
+//==============================================================================
+// node v0.11 implementation
+//==============================================================================
+
+namespace imp {
+
+//=== Array ====================================================================
+
+Factory<v8::Array>::return_t
+Factory<v8::Array>::New() {
+  return v8::Array::New(v8::Isolate::GetCurrent());
+}
+
+Factory<v8::Array>::return_t
+Factory<v8::Array>::New(int length) {
+  return v8::Array::New(v8::Isolate::GetCurrent(), length);
+}
+
+//=== Boolean ==================================================================
+
+Factory<v8::Boolean>::return_t
+Factory<v8::Boolean>::New(bool value) {
+  return v8::Boolean::New(v8::Isolate::GetCurrent(), value);
+}
+
+//=== Boolean Object ===========================================================
+
+Factory<v8::BooleanObject>::return_t
+Factory<v8::BooleanObject>::New(bool value) {
+  return v8::BooleanObject::New(value).As<v8::BooleanObject>();
+}
+
+//=== Context ==================================================================
+
+Factory<v8::Context>::return_t
+Factory<v8::Context>::New( v8::ExtensionConfiguration* extensions
+                         , v8::Local<v8::ObjectTemplate> tmpl
+                         , v8::Local<v8::Value> obj) {
+  return v8::Context::New(v8::Isolate::GetCurrent(), extensions, tmpl, obj);
+}
+
+//=== Date =====================================================================
+
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
+  (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
+Factory<v8::Date>::return_t
+Factory<v8::Date>::New(double value) {
+  v8::Local<v8::Date> ret;
+  if (v8::Date::New(GetCurrentContext(), value).
+      ToLocal(reinterpret_cast<v8::Local<v8::Value>*>(&ret))) {
+    return v8::MaybeLocal<v8::Date>(ret);
+  } else {
+    return v8::MaybeLocal<v8::Date>(ret);
+  }
+}
+#else
+Factory<v8::Date>::return_t
+Factory<v8::Date>::New(double value) {
+  return Factory<v8::Date>::return_t(
+      v8::Date::New(v8::Isolate::GetCurrent(), value).As<v8::Date>());
+}
+#endif
+
+//=== External =================================================================
+
+Factory<v8::External>::return_t
+Factory<v8::External>::New(void * value) {
+  return v8::External::New(v8::Isolate::GetCurrent(), value);
+}
+
+//=== Function =================================================================
+
+Factory<v8::Function>::return_t
+Factory<v8::Function>::New( FunctionCallback callback
+                          , v8::Local<v8::Value> data) {
+  v8::Isolate *isolate = v8::Isolate::GetCurrent();
+  v8::EscapableHandleScope scope(isolate);
+  v8::Local<v8::ObjectTemplate> tpl = v8::ObjectTemplate::New(isolate);
+  tpl->SetInternalFieldCount(imp::kFunctionFieldCount);
+  v8::Local<v8::Object> obj = NewInstance(tpl).ToLocalChecked();
+
+  obj->SetInternalField(
+      imp::kFunctionIndex
+    , v8::External::New(isolate, reinterpret_cast<void *>(callback)));
+
+  v8::Local<v8::Value> val = v8::Local<v8::Value>::New(isolate, data);
+
+  if (!val.IsEmpty()) {
+    obj->SetInternalField(imp::kDataIndex, val);
+  }
+
+  return scope.Escape(v8::Function::New( isolate
+                          , imp::FunctionCallbackWrapper
+                          , obj));
+}
+
+//=== Function Template ========================================================
+
+Factory<v8::FunctionTemplate>::return_t
+Factory<v8::FunctionTemplate>::New( FunctionCallback callback
+                                  , v8::Local<v8::Value> data
+                                  , v8::Local<v8::Signature> signature) {
+  v8::Isolate *isolate = v8::Isolate::GetCurrent();
+  if (callback) {
+    v8::EscapableHandleScope scope(isolate);
+    v8::Local<v8::ObjectTemplate> tpl = v8::ObjectTemplate::New(isolate);
+    tpl->SetInternalFieldCount(imp::kFunctionFieldCount);
+    v8::Local<v8::Object> obj = NewInstance(tpl).ToLocalChecked();
+
+    obj->SetInternalField(
+        imp::kFunctionIndex
+      , v8::External::New(isolate, reinterpret_cast<void *>(callback)));
+    v8::Local<v8::Value> val = v8::Local<v8::Value>::New(isolate, data);
+
+    if (!val.IsEmpty()) {
+      obj->SetInternalField(imp::kDataIndex, val);
+    }
+
+    return scope.Escape(v8::FunctionTemplate::New( isolate
+                                    , imp::FunctionCallbackWrapper
+                                    , obj
+                                    , signature));
+  } else {
+    return v8::FunctionTemplate::New(isolate, 0, data, signature);
+  }
+}
+
+//=== Number ===================================================================
+
+Factory<v8::Number>::return_t
+Factory<v8::Number>::New(double value) {
+  return v8::Number::New(v8::Isolate::GetCurrent(), value);
+}
+
+//=== Number Object ============================================================
+
+Factory<v8::NumberObject>::return_t
+Factory<v8::NumberObject>::New(double value) {
+  return v8::NumberObject::New( v8::Isolate::GetCurrent()
+                              , value).As<v8::NumberObject>();
+}
+
+//=== Integer, Int32 and Uint32 ================================================
+
+template <typename T>
+typename IntegerFactory<T>::return_t
+IntegerFactory<T>::New(int32_t value) {
+  return To<T>(T::New(v8::Isolate::GetCurrent(), value));
+}
+
+template <typename T>
+typename IntegerFactory<T>::return_t
+IntegerFactory<T>::New(uint32_t value) {
+  return To<T>(T::NewFromUnsigned(v8::Isolate::GetCurrent(), value));
+}
+
+Factory<v8::Uint32>::return_t
+Factory<v8::Uint32>::New(int32_t value) {
+  return To<v8::Uint32>(
+      v8::Uint32::NewFromUnsigned(v8::Isolate::GetCurrent(), value));
+}
+
+Factory<v8::Uint32>::return_t
+Factory<v8::Uint32>::New(uint32_t value) {
+  return To<v8::Uint32>(
+      v8::Uint32::NewFromUnsigned(v8::Isolate::GetCurrent(), value));
+}
+
+//=== Object ===================================================================
+
+Factory<v8::Object>::return_t
+Factory<v8::Object>::New() {
+  return v8::Object::New(v8::Isolate::GetCurrent());
+}
+
+//=== Object Template ==========================================================
+
+Factory<v8::ObjectTemplate>::return_t
+Factory<v8::ObjectTemplate>::New() {
+  return v8::ObjectTemplate::New(v8::Isolate::GetCurrent());
+}
+
+//=== RegExp ===================================================================
+
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
+  (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
+Factory<v8::RegExp>::return_t
+Factory<v8::RegExp>::New(
+    v8::Local<v8::String> pattern
+  , v8::RegExp::Flags flags) {
+  return v8::RegExp::New(GetCurrentContext(), pattern, flags);
+}
+#else
+Factory<v8::RegExp>::return_t
+Factory<v8::RegExp>::New(
+    v8::Local<v8::String> pattern
+  , v8::RegExp::Flags flags) {
+  return Factory<v8::RegExp>::return_t(v8::RegExp::New(pattern, flags));
+}
+#endif
+
+//=== Script ===================================================================
+
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
+  (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
+Factory<v8::Script>::return_t
+Factory<v8::Script>::New( v8::Local<v8::String> source) {
+  v8::ScriptCompiler::Source src(source);
+  return v8::ScriptCompiler::Compile(GetCurrentContext(), &src);
+}
+
+Factory<v8::Script>::return_t
+Factory<v8::Script>::New( v8::Local<v8::String> source
+                        , v8::ScriptOrigin const& origin) {
+  v8::ScriptCompiler::Source src(source, origin);
+  return v8::ScriptCompiler::Compile(GetCurrentContext(), &src);
+}
+#else
+Factory<v8::Script>::return_t
+Factory<v8::Script>::New( v8::Local<v8::String> source) {
+  v8::ScriptCompiler::Source src(source);
+  return Factory<v8::Script>::return_t(
+      v8::ScriptCompiler::Compile(v8::Isolate::GetCurrent(), &src));
+}
+
+Factory<v8::Script>::return_t
+Factory<v8::Script>::New( v8::Local<v8::String> source
+                        , v8::ScriptOrigin const& origin) {
+  v8::ScriptCompiler::Source src(source, origin);
+  return Factory<v8::Script>::return_t(
+      v8::ScriptCompiler::Compile(v8::Isolate::GetCurrent(), &src));
+}
+#endif
+
+//=== Signature ================================================================
+
+Factory<v8::Signature>::return_t
+Factory<v8::Signature>::New(Factory<v8::Signature>::FTH receiver) {
+  return v8::Signature::New(v8::Isolate::GetCurrent(), receiver);
+}
+
+//=== String ===================================================================
+
+Factory<v8::String>::return_t
+Factory<v8::String>::New() {
+  return Factory<v8::String>::return_t(
+      v8::String::Empty(v8::Isolate::GetCurrent()));
+}
+
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
+  (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
+Factory<v8::String>::return_t
+Factory<v8::String>::New(const char * value, int length) {
+  return v8::String::NewFromUtf8(
+      v8::Isolate::GetCurrent(), value, v8::NewStringType::kNormal, length);
+}
+
+Factory<v8::String>::return_t
+Factory<v8::String>::New(std::string const& value) {
+  assert(value.size() <= INT_MAX && "string too long");
+  return v8::String::NewFromUtf8(v8::Isolate::GetCurrent(),
+      value.data(), v8::NewStringType::kNormal, static_cast<int>(value.size()));
+}
+
+Factory<v8::String>::return_t
+Factory<v8::String>::New(const uint16_t * value, int length) {
+  return v8::String::NewFromTwoByte(v8::Isolate::GetCurrent(), value,
+        v8::NewStringType::kNormal, length);
+}
+
+Factory<v8::String>::return_t
+Factory<v8::String>::New(v8::String::ExternalStringResource * value) {
+  return v8::String::NewExternalTwoByte(v8::Isolate::GetCurrent(), value);
+}
+
+Factory<v8::String>::return_t
+Factory<v8::String>::New(ExternalOneByteStringResource * value) {
+  return v8::String::NewExternalOneByte(v8::Isolate::GetCurrent(), value);
+}
+#else
+Factory<v8::String>::return_t
+Factory<v8::String>::New(const char * value, int length) {
+  return Factory<v8::String>::return_t(
+      v8::String::NewFromUtf8(
+          v8::Isolate::GetCurrent()
+        , value
+        , v8::String::kNormalString
+        , length));
+}
+
+Factory<v8::String>::return_t
+Factory<v8::String>::New(
+    std::string const& value) /* NOLINT(build/include_what_you_use) */ {
+  assert(value.size() <= INT_MAX && "string too long");
+  return Factory<v8::String>::return_t(
+      v8::String::NewFromUtf8(
+          v8::Isolate::GetCurrent()
+        , value.data()
+        , v8::String::kNormalString
+        , static_cast<int>(value.size())));
+}
+
+Factory<v8::String>::return_t
+Factory<v8::String>::New(const uint16_t * value, int length) {
+  return Factory<v8::String>::return_t(
+      v8::String::NewFromTwoByte(
+          v8::Isolate::GetCurrent()
+        , value
+        , v8::String::kNormalString
+        , length));
+}
+
+Factory<v8::String>::return_t
+Factory<v8::String>::New(v8::String::ExternalStringResource * value) {
+  return Factory<v8::String>::return_t(
+      v8::String::NewExternal(v8::Isolate::GetCurrent(), value));
+}
+
+Factory<v8::String>::return_t
+Factory<v8::String>::New(ExternalOneByteStringResource * value) {
+  return Factory<v8::String>::return_t(
+      v8::String::NewExternal(v8::Isolate::GetCurrent(), value));
+}
+#endif
+
+//=== String Object ============================================================
+
+Factory<v8::StringObject>::return_t
+Factory<v8::StringObject>::New(v8::Local<v8::String> value) {
+  return v8::StringObject::New(value).As<v8::StringObject>();
+}
+
+//=== Unbound Script ===========================================================
+
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
+  (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
+Factory<v8::UnboundScript>::return_t
+Factory<v8::UnboundScript>::New(v8::Local<v8::String> source) {
+  v8::ScriptCompiler::Source src(source);
+  return v8::ScriptCompiler::CompileUnboundScript(
+      v8::Isolate::GetCurrent(), &src);
+}
+
+Factory<v8::UnboundScript>::return_t
+Factory<v8::UnboundScript>::New( v8::Local<v8::String> source
+                               , v8::ScriptOrigin const& origin) {
+  v8::ScriptCompiler::Source src(source, origin);
+  return v8::ScriptCompiler::CompileUnboundScript(
+      v8::Isolate::GetCurrent(), &src);
+}
+#else
+Factory<v8::UnboundScript>::return_t
+Factory<v8::UnboundScript>::New(v8::Local<v8::String> source) {
+  v8::ScriptCompiler::Source src(source);
+  return Factory<v8::UnboundScript>::return_t(
+      v8::ScriptCompiler::CompileUnbound(v8::Isolate::GetCurrent(), &src));
+}
+
+Factory<v8::UnboundScript>::return_t
+Factory<v8::UnboundScript>::New( v8::Local<v8::String> source
+                               , v8::ScriptOrigin const& origin) {
+  v8::ScriptCompiler::Source src(source, origin);
+  return Factory<v8::UnboundScript>::return_t(
+      v8::ScriptCompiler::CompileUnbound(v8::Isolate::GetCurrent(), &src));
+}
+#endif
+
+}  // end of namespace imp
+
+//=== Presistents and Handles ==================================================
+
+#if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
+template <typename T>
+inline v8::Local<T> New(v8::Handle<T> h) {
+  return v8::Local<T>::New(v8::Isolate::GetCurrent(), h);
+}
+#endif
+
+template <typename T, typename M>
+inline v8::Local<T> New(v8::Persistent<T, M> const& p) {
+  return v8::Local<T>::New(v8::Isolate::GetCurrent(), p);
+}
+
+template <typename T, typename M>
+inline v8::Local<T> New(Persistent<T, M> const& p) {
+  return v8::Local<T>::New(v8::Isolate::GetCurrent(), p);
+}
+
+template <typename T>
+inline v8::Local<T> New(Global<T> const& p) {
+  return v8::Local<T>::New(v8::Isolate::GetCurrent(), p);
+}
+
+#endif  // NAN_IMPLEMENTATION_12_INL_H_

--- a/deps/nan/nan_implementation_pre_12_inl.h
+++ b/deps/nan/nan_implementation_pre_12_inl.h
@@ -1,0 +1,264 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2015 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+#ifndef NAN_IMPLEMENTATION_PRE_12_INL_H_
+#define NAN_IMPLEMENTATION_PRE_12_INL_H_
+
+//==============================================================================
+// node v0.10 implementation
+//==============================================================================
+
+namespace imp {
+
+//=== Array ====================================================================
+
+Factory<v8::Array>::return_t
+Factory<v8::Array>::New() {
+  return v8::Array::New();
+}
+
+Factory<v8::Array>::return_t
+Factory<v8::Array>::New(int length) {
+  return v8::Array::New(length);
+}
+
+//=== Boolean ==================================================================
+
+Factory<v8::Boolean>::return_t
+Factory<v8::Boolean>::New(bool value) {
+  return v8::Boolean::New(value)->ToBoolean();
+}
+
+//=== Boolean Object ===========================================================
+
+Factory<v8::BooleanObject>::return_t
+Factory<v8::BooleanObject>::New(bool value) {
+  return v8::BooleanObject::New(value).As<v8::BooleanObject>();
+}
+
+//=== Context ==================================================================
+
+Factory<v8::Context>::return_t
+Factory<v8::Context>::New( v8::ExtensionConfiguration* extensions
+                         , v8::Local<v8::ObjectTemplate> tmpl
+                         , v8::Local<v8::Value> obj) {
+  v8::Persistent<v8::Context> ctx = v8::Context::New(extensions, tmpl, obj);
+  v8::Local<v8::Context> lctx = v8::Local<v8::Context>::New(ctx);
+  ctx.Dispose();
+  return lctx;
+}
+
+//=== Date =====================================================================
+
+Factory<v8::Date>::return_t
+Factory<v8::Date>::New(double value) {
+  return Factory<v8::Date>::return_t(v8::Date::New(value).As<v8::Date>());
+}
+
+//=== External =================================================================
+
+Factory<v8::External>::return_t
+Factory<v8::External>::New(void * value) {
+  return v8::External::New(value);
+}
+
+//=== Function =================================================================
+
+Factory<v8::Function>::return_t
+Factory<v8::Function>::New( FunctionCallback callback
+                          , v8::Local<v8::Value> data) {
+  return Factory<v8::FunctionTemplate>::New( callback
+                                           , data
+                                           , v8::Local<v8::Signature>()
+                                           )->GetFunction();
+}
+
+
+//=== FunctionTemplate =========================================================
+
+Factory<v8::FunctionTemplate>::return_t
+Factory<v8::FunctionTemplate>::New( FunctionCallback callback
+                                  , v8::Local<v8::Value> data
+                                  , v8::Local<v8::Signature> signature) {
+  if (callback) {
+    v8::HandleScope scope;
+
+    v8::Local<v8::ObjectTemplate> tpl = v8::ObjectTemplate::New();
+    tpl->SetInternalFieldCount(imp::kFunctionFieldCount);
+    v8::Local<v8::Object> obj = tpl->NewInstance();
+
+    obj->SetInternalField(
+        imp::kFunctionIndex
+      , v8::External::New(reinterpret_cast<void *>(callback)));
+
+    v8::Local<v8::Value> val = v8::Local<v8::Value>::New(data);
+
+    if (!val.IsEmpty()) {
+      obj->SetInternalField(imp::kDataIndex, val);
+    }
+
+    // Note(agnat): Emulate length argument here. Unfortunately, I couldn't find
+    // a way. Have at it though...
+    return scope.Close(
+        v8::FunctionTemplate::New(imp::FunctionCallbackWrapper
+                                 , obj
+                                 , signature));
+  } else {
+    return v8::FunctionTemplate::New(0, data, signature);
+  }
+}
+
+//=== Number ===================================================================
+
+Factory<v8::Number>::return_t
+Factory<v8::Number>::New(double value) {
+  return v8::Number::New(value);
+}
+
+//=== Number Object ============================================================
+
+Factory<v8::NumberObject>::return_t
+Factory<v8::NumberObject>::New(double value) {
+  return v8::NumberObject::New(value).As<v8::NumberObject>();
+}
+
+//=== Integer, Int32 and Uint32 ================================================
+
+template <typename T>
+typename IntegerFactory<T>::return_t
+IntegerFactory<T>::New(int32_t value) {
+  return To<T>(T::New(value));
+}
+
+template <typename T>
+typename IntegerFactory<T>::return_t
+IntegerFactory<T>::New(uint32_t value) {
+  return To<T>(T::NewFromUnsigned(value));
+}
+
+Factory<v8::Uint32>::return_t
+Factory<v8::Uint32>::New(int32_t value) {
+  return To<v8::Uint32>(v8::Uint32::NewFromUnsigned(value));
+}
+
+Factory<v8::Uint32>::return_t
+Factory<v8::Uint32>::New(uint32_t value) {
+  return To<v8::Uint32>(v8::Uint32::NewFromUnsigned(value));
+}
+
+
+//=== Object ===================================================================
+
+Factory<v8::Object>::return_t
+Factory<v8::Object>::New() {
+  return v8::Object::New();
+}
+
+//=== Object Template ==========================================================
+
+Factory<v8::ObjectTemplate>::return_t
+Factory<v8::ObjectTemplate>::New() {
+  return v8::ObjectTemplate::New();
+}
+
+//=== RegExp ===================================================================
+
+Factory<v8::RegExp>::return_t
+Factory<v8::RegExp>::New(
+    v8::Local<v8::String> pattern
+  , v8::RegExp::Flags flags) {
+  return Factory<v8::RegExp>::return_t(v8::RegExp::New(pattern, flags));
+}
+
+//=== Script ===================================================================
+
+Factory<v8::Script>::return_t
+Factory<v8::Script>::New( v8::Local<v8::String> source) {
+  return Factory<v8::Script>::return_t(v8::Script::New(source));
+}
+Factory<v8::Script>::return_t
+Factory<v8::Script>::New( v8::Local<v8::String> source
+                        , v8::ScriptOrigin const& origin) {
+  return Factory<v8::Script>::return_t(
+      v8::Script::New(source, const_cast<v8::ScriptOrigin*>(&origin)));
+}
+
+//=== Signature ================================================================
+
+Factory<v8::Signature>::return_t
+Factory<v8::Signature>::New(Factory<v8::Signature>::FTH receiver) {
+  return v8::Signature::New(receiver);
+}
+
+//=== String ===================================================================
+
+Factory<v8::String>::return_t
+Factory<v8::String>::New() {
+  return Factory<v8::String>::return_t(v8::String::Empty());
+}
+
+Factory<v8::String>::return_t
+Factory<v8::String>::New(const char * value, int length) {
+  return Factory<v8::String>::return_t(v8::String::New(value, length));
+}
+
+Factory<v8::String>::return_t
+Factory<v8::String>::New(
+    std::string const& value) /* NOLINT(build/include_what_you_use) */ {
+  assert(value.size() <= INT_MAX && "string too long");
+  return Factory<v8::String>::return_t(
+      v8::String::New( value.data(), static_cast<int>(value.size())));
+}
+
+Factory<v8::String>::return_t
+Factory<v8::String>::New(const uint16_t * value, int length) {
+  return Factory<v8::String>::return_t(v8::String::New(value, length));
+}
+
+Factory<v8::String>::return_t
+Factory<v8::String>::New(v8::String::ExternalStringResource * value) {
+  return Factory<v8::String>::return_t(v8::String::NewExternal(value));
+}
+
+Factory<v8::String>::return_t
+Factory<v8::String>::New(v8::String::ExternalAsciiStringResource * value) {
+  return Factory<v8::String>::return_t(v8::String::NewExternal(value));
+}
+
+//=== String Object ============================================================
+
+Factory<v8::StringObject>::return_t
+Factory<v8::StringObject>::New(v8::Local<v8::String> value) {
+  return v8::StringObject::New(value).As<v8::StringObject>();
+}
+
+}  // end of namespace imp
+
+//=== Presistents and Handles ==================================================
+
+template <typename T>
+inline v8::Local<T> New(v8::Handle<T> h) {
+  return v8::Local<T>::New(h);
+}
+
+template <typename T>
+inline v8::Local<T> New(v8::Persistent<T> const& p) {
+  return v8::Local<T>::New(p);
+}
+
+template <typename T, typename M>
+inline v8::Local<T> New(Persistent<T, M> const& p) {
+  return v8::Local<T>::New(p.persistent);
+}
+
+template <typename T>
+inline v8::Local<T> New(Global<T> const& p) {
+  return v8::Local<T>::New(p.persistent);
+}
+
+#endif  // NAN_IMPLEMENTATION_PRE_12_INL_H_

--- a/deps/nan/nan_maybe_43_inl.h
+++ b/deps/nan/nan_maybe_43_inl.h
@@ -1,0 +1,224 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2015 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+#ifndef NAN_MAYBE_43_INL_H_
+#define NAN_MAYBE_43_INL_H_
+
+template<typename T>
+using MaybeLocal = v8::MaybeLocal<T>;
+
+template<typename T>
+using Maybe = v8::Maybe<T>;
+
+template<typename T>
+NAN_INLINE Maybe<T> Nothing() {
+  return v8::Nothing<T>();
+}
+
+template<typename T>
+NAN_INLINE Maybe<T> Just(const T& t) {
+  return v8::Just<T>(t);
+}
+
+v8::Local<v8::Context> GetCurrentContext();
+
+NAN_INLINE
+MaybeLocal<v8::String> ToDetailString(v8::Local<v8::Value> val) {
+  return val->ToDetailString(GetCurrentContext());
+}
+
+NAN_INLINE
+MaybeLocal<v8::Uint32> ToArrayIndex(v8::Local<v8::Value> val) {
+  return val->ToArrayIndex(GetCurrentContext());
+}
+
+NAN_INLINE
+Maybe<bool> Equals(v8::Local<v8::Value> a, v8::Local<v8::Value>(b)) {
+  return a->Equals(GetCurrentContext(), b);
+}
+
+NAN_INLINE
+MaybeLocal<v8::Object> NewInstance(v8::Local<v8::Function> h) {
+  return MaybeLocal<v8::Object>(h->NewInstance(GetCurrentContext()));
+}
+
+NAN_INLINE
+MaybeLocal<v8::Object> NewInstance(
+      v8::Local<v8::Function> h
+    , int argc
+    , v8::Local<v8::Value> argv[]) {
+  return MaybeLocal<v8::Object>(h->NewInstance(GetCurrentContext(),
+                                argc, argv));
+}
+
+NAN_INLINE
+MaybeLocal<v8::Object> NewInstance(v8::Local<v8::ObjectTemplate> h) {
+  return MaybeLocal<v8::Object>(h->NewInstance(GetCurrentContext()));
+}
+
+
+NAN_INLINE MaybeLocal<v8::Function> GetFunction(
+    v8::Local<v8::FunctionTemplate> t) {
+  return t->GetFunction(GetCurrentContext());
+}
+
+NAN_INLINE Maybe<bool> Set(
+    v8::Local<v8::Object> obj
+  , v8::Local<v8::Value> key
+  , v8::Local<v8::Value> value) {
+  return obj->Set(GetCurrentContext(), key, value);
+}
+
+NAN_INLINE Maybe<bool> Set(
+    v8::Local<v8::Object> obj
+  , uint32_t index
+  , v8::Local<v8::Value> value) {
+  return obj->Set(GetCurrentContext(), index, value);
+}
+
+NAN_INLINE Maybe<bool> ForceSet(
+    v8::Local<v8::Object> obj
+  , v8::Local<v8::Value> key
+  , v8::Local<v8::Value> value
+  , v8::PropertyAttribute attribs = v8::None) {
+  return obj->ForceSet(GetCurrentContext(), key, value, attribs);
+}
+
+NAN_INLINE MaybeLocal<v8::Value> Get(
+    v8::Local<v8::Object> obj
+  , v8::Local<v8::Value> key) {
+  return obj->Get(GetCurrentContext(), key);
+}
+
+NAN_INLINE
+MaybeLocal<v8::Value> Get(v8::Local<v8::Object> obj, uint32_t index) {
+  return obj->Get(GetCurrentContext(), index);
+}
+
+NAN_INLINE v8::PropertyAttribute GetPropertyAttributes(
+    v8::Local<v8::Object> obj
+  , v8::Local<v8::Value> key) {
+  return obj->GetPropertyAttributes(GetCurrentContext(), key).FromJust();
+}
+
+NAN_INLINE Maybe<bool> Has(
+    v8::Local<v8::Object> obj
+  , v8::Local<v8::String> key) {
+  return obj->Has(GetCurrentContext(), key);
+}
+
+NAN_INLINE Maybe<bool> Has(v8::Local<v8::Object> obj, uint32_t index) {
+  return obj->Has(GetCurrentContext(), index);
+}
+
+NAN_INLINE Maybe<bool> Delete(
+    v8::Local<v8::Object> obj
+  , v8::Local<v8::String> key) {
+  return obj->Delete(GetCurrentContext(), key);
+}
+
+NAN_INLINE
+Maybe<bool> Delete(v8::Local<v8::Object> obj, uint32_t index) {
+  return obj->Delete(GetCurrentContext(), index);
+}
+
+NAN_INLINE
+MaybeLocal<v8::Array> GetPropertyNames(v8::Local<v8::Object> obj) {
+  return obj->GetPropertyNames(GetCurrentContext());
+}
+
+NAN_INLINE
+MaybeLocal<v8::Array> GetOwnPropertyNames(v8::Local<v8::Object> obj) {
+  return obj->GetOwnPropertyNames(GetCurrentContext());
+}
+
+NAN_INLINE Maybe<bool> SetPrototype(
+    v8::Local<v8::Object> obj
+  , v8::Local<v8::Value> prototype) {
+  return obj->SetPrototype(GetCurrentContext(), prototype);
+}
+
+NAN_INLINE MaybeLocal<v8::String> ObjectProtoToString(
+    v8::Local<v8::Object> obj) {
+  return obj->ObjectProtoToString(GetCurrentContext());
+}
+
+NAN_INLINE Maybe<bool> HasOwnProperty(
+    v8::Local<v8::Object> obj
+  , v8::Local<v8::String> key) {
+  return obj->HasOwnProperty(GetCurrentContext(), key);
+}
+
+NAN_INLINE Maybe<bool> HasRealNamedProperty(
+    v8::Local<v8::Object> obj
+  , v8::Local<v8::String> key) {
+  return obj->HasRealNamedProperty(GetCurrentContext(), key);
+}
+
+NAN_INLINE Maybe<bool> HasRealIndexedProperty(
+    v8::Local<v8::Object> obj
+  , uint32_t index) {
+  return obj->HasRealIndexedProperty(GetCurrentContext(), index);
+}
+
+NAN_INLINE Maybe<bool> HasRealNamedCallbackProperty(
+    v8::Local<v8::Object> obj
+  , v8::Local<v8::String> key) {
+  return obj->HasRealNamedCallbackProperty(GetCurrentContext(), key);
+}
+
+NAN_INLINE MaybeLocal<v8::Value> GetRealNamedPropertyInPrototypeChain(
+    v8::Local<v8::Object> obj
+  , v8::Local<v8::String> key) {
+  return obj->GetRealNamedPropertyInPrototypeChain(GetCurrentContext(), key);
+}
+
+NAN_INLINE MaybeLocal<v8::Value> GetRealNamedProperty(
+    v8::Local<v8::Object> obj
+  , v8::Local<v8::String> key) {
+  return obj->GetRealNamedProperty(GetCurrentContext(), key);
+}
+
+NAN_INLINE MaybeLocal<v8::Value> CallAsFunction(
+    v8::Local<v8::Object> obj
+  , v8::Local<v8::Object> recv
+  , int argc
+  , v8::Local<v8::Value> argv[]) {
+  return obj->CallAsFunction(GetCurrentContext(), recv, argc, argv);
+}
+
+NAN_INLINE MaybeLocal<v8::Value> CallAsConstructor(
+    v8::Local<v8::Object> obj
+  , int argc, v8::Local<v8::Value> argv[]) {
+  return obj->CallAsConstructor(GetCurrentContext(), argc, argv);
+}
+
+NAN_INLINE
+MaybeLocal<v8::String> GetSourceLine(v8::Local<v8::Message> msg) {
+  return msg->GetSourceLine(GetCurrentContext());
+}
+
+NAN_INLINE Maybe<int> GetLineNumber(v8::Local<v8::Message> msg) {
+  return msg->GetLineNumber(GetCurrentContext());
+}
+
+NAN_INLINE Maybe<int> GetStartColumn(v8::Local<v8::Message> msg) {
+  return msg->GetStartColumn(GetCurrentContext());
+}
+
+NAN_INLINE Maybe<int> GetEndColumn(v8::Local<v8::Message> msg) {
+  return msg->GetEndColumn(GetCurrentContext());
+}
+
+NAN_INLINE MaybeLocal<v8::Object> CloneElementAt(
+    v8::Local<v8::Array> array
+  , uint32_t index) {
+  return array->CloneElementAt(GetCurrentContext(), index);
+}
+
+#endif  // NAN_MAYBE_43_INL_H_

--- a/deps/nan/nan_maybe_pre_43_inl.h
+++ b/deps/nan/nan_maybe_pre_43_inl.h
@@ -1,0 +1,295 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2015 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+#ifndef NAN_MAYBE_PRE_43_INL_H_
+#define NAN_MAYBE_PRE_43_INL_H_
+
+template<typename T>
+class MaybeLocal {
+ public:
+  NAN_INLINE MaybeLocal() : val_(v8::Local<T>()) {}
+
+  template<typename S>
+# if NODE_MODULE_VERSION >= NODE_0_12_MODULE_VERSION
+  NAN_INLINE MaybeLocal(v8::Local<S> that) : val_(that) {}
+# else
+  NAN_INLINE MaybeLocal(v8::Local<S> that) :
+      val_(*reinterpret_cast<v8::Local<T>*>(&that)) {}
+# endif
+
+  NAN_INLINE bool IsEmpty() const { return val_.IsEmpty(); }
+
+  template<typename S>
+  NAN_INLINE bool ToLocal(v8::Local<S> *out) const {
+    *out = val_;
+    return !IsEmpty();
+  }
+
+  NAN_INLINE v8::Local<T> ToLocalChecked() const {
+#if defined(V8_ENABLE_CHECKS)
+    assert(!IsEmpty() && "ToLocalChecked is Empty");
+#endif  // V8_ENABLE_CHECKS
+    return val_;
+  }
+
+  template<typename S>
+  NAN_INLINE v8::Local<S> FromMaybe(v8::Local<S> default_value) const {
+    return IsEmpty() ? default_value : val_;
+  }
+
+ private:
+  v8::Local<T> val_;
+};
+
+template<typename T>
+class Maybe {
+ public:
+  NAN_INLINE bool IsNothing() const { return !has_value_; }
+  NAN_INLINE bool IsJust() const { return has_value_; }
+
+  NAN_INLINE T FromJust() const {
+#if defined(V8_ENABLE_CHECKS)
+    assert(IsJust() && "FromJust is Nothing");
+#endif  // V8_ENABLE_CHECKS
+    return value_;
+  }
+
+  NAN_INLINE T FromMaybe(const T& default_value) const {
+    return has_value_ ? value_ : default_value;
+  }
+
+  NAN_INLINE bool operator==(const Maybe &other) const {
+    return (IsJust() == other.IsJust()) &&
+        (!IsJust() || FromJust() == other.FromJust());
+  }
+
+  NAN_INLINE bool operator!=(const Maybe &other) const {
+    return !operator==(other);
+  }
+
+ private:
+  Maybe() : has_value_(false) {}
+  explicit Maybe(const T& t) : has_value_(true), value_(t) {}
+  bool has_value_;
+  T value_;
+
+  template<typename U>
+  friend Maybe<U> Nothing();
+  template<typename U>
+  friend Maybe<U> Just(const U& u);
+};
+
+template<typename T>
+inline Maybe<T> Nothing() {
+  return Maybe<T>();
+}
+
+template<typename T>
+inline Maybe<T> Just(const T& t) {
+  return Maybe<T>(t);
+}
+
+NAN_INLINE
+MaybeLocal<v8::String> ToDetailString(v8::Handle<v8::Value> val) {
+  return MaybeLocal<v8::String>(val->ToDetailString());
+}
+
+NAN_INLINE
+MaybeLocal<v8::Uint32> ToArrayIndex(v8::Handle<v8::Value> val) {
+  return MaybeLocal<v8::Uint32>(val->ToArrayIndex());
+}
+
+NAN_INLINE
+Maybe<bool> Equals(v8::Handle<v8::Value> a, v8::Handle<v8::Value>(b)) {
+  return Just<bool>(a->Equals(b));
+}
+
+NAN_INLINE
+MaybeLocal<v8::Object> NewInstance(v8::Handle<v8::Function> h) {
+  return MaybeLocal<v8::Object>(h->NewInstance());
+}
+
+NAN_INLINE
+MaybeLocal<v8::Object> NewInstance(
+      v8::Local<v8::Function> h
+    , int argc
+    , v8::Local<v8::Value> argv[]) {
+  return MaybeLocal<v8::Object>(h->NewInstance(argc, argv));
+}
+
+NAN_INLINE
+MaybeLocal<v8::Object> NewInstance(v8::Handle<v8::ObjectTemplate> h) {
+  return MaybeLocal<v8::Object>(h->NewInstance());
+}
+
+NAN_INLINE
+MaybeLocal<v8::Function> GetFunction(v8::Handle<v8::FunctionTemplate> t) {
+  return MaybeLocal<v8::Function>(t->GetFunction());
+}
+
+NAN_INLINE Maybe<bool> Set(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::Value> key
+  , v8::Handle<v8::Value> value) {
+  return Just<bool>(obj->Set(key, value));
+}
+
+NAN_INLINE Maybe<bool> Set(
+    v8::Handle<v8::Object> obj
+  , uint32_t index
+  , v8::Handle<v8::Value> value) {
+  return Just<bool>(obj->Set(index, value));
+}
+
+NAN_INLINE Maybe<bool> ForceSet(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::Value> key
+  , v8::Handle<v8::Value> value
+  , v8::PropertyAttribute attribs = v8::None) {
+  return Just<bool>(obj->ForceSet(key, value, attribs));
+}
+
+NAN_INLINE MaybeLocal<v8::Value> Get(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::Value> key) {
+  return MaybeLocal<v8::Value>(obj->Get(key));
+}
+
+NAN_INLINE MaybeLocal<v8::Value> Get(
+    v8::Handle<v8::Object> obj
+  , uint32_t index) {
+  return MaybeLocal<v8::Value>(obj->Get(index));
+}
+
+NAN_INLINE Maybe<v8::PropertyAttribute> GetPropertyAttributes(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::Value> key) {
+  return Just<v8::PropertyAttribute>(obj->GetPropertyAttributes(key));
+}
+
+NAN_INLINE Maybe<bool> Has(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::String> key) {
+  return Just<bool>(obj->Has(key));
+}
+
+NAN_INLINE Maybe<bool> Has(
+    v8::Handle<v8::Object> obj
+  , uint32_t index) {
+  return Just<bool>(obj->Has(index));
+}
+
+NAN_INLINE Maybe<bool> Delete(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::String> key) {
+  return Just<bool>(obj->Delete(key));
+}
+
+NAN_INLINE Maybe<bool> Delete(
+    v8::Handle<v8::Object> obj
+  , uint32_t index) {
+  return Just<bool>(obj->Delete(index));
+}
+
+NAN_INLINE
+MaybeLocal<v8::Array> GetPropertyNames(v8::Handle<v8::Object> obj) {
+  return MaybeLocal<v8::Array>(obj->GetPropertyNames());
+}
+
+NAN_INLINE
+MaybeLocal<v8::Array> GetOwnPropertyNames(v8::Handle<v8::Object> obj) {
+  return MaybeLocal<v8::Array>(obj->GetOwnPropertyNames());
+}
+
+NAN_INLINE Maybe<bool> SetPrototype(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::Value> prototype) {
+  return Just<bool>(obj->SetPrototype(prototype));
+}
+
+NAN_INLINE MaybeLocal<v8::String> ObjectProtoToString(
+    v8::Handle<v8::Object> obj) {
+  return MaybeLocal<v8::String>(obj->ObjectProtoToString());
+}
+
+NAN_INLINE Maybe<bool> HasOwnProperty(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::String> key) {
+  return Just<bool>(obj->HasOwnProperty(key));
+}
+
+NAN_INLINE Maybe<bool> HasRealNamedProperty(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::String> key) {
+  return Just<bool>(obj->HasRealNamedProperty(key));
+}
+
+NAN_INLINE Maybe<bool> HasRealIndexedProperty(
+    v8::Handle<v8::Object> obj
+  , uint32_t index) {
+  return Just<bool>(obj->HasRealIndexedProperty(index));
+}
+
+NAN_INLINE Maybe<bool> HasRealNamedCallbackProperty(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::String> key) {
+  return Just<bool>(obj->HasRealNamedCallbackProperty(key));
+}
+
+NAN_INLINE MaybeLocal<v8::Value> GetRealNamedPropertyInPrototypeChain(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::String> key) {
+  return MaybeLocal<v8::Value>(
+      obj->GetRealNamedPropertyInPrototypeChain(key));
+}
+
+NAN_INLINE MaybeLocal<v8::Value> GetRealNamedProperty(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::String> key) {
+  return MaybeLocal<v8::Value>(obj->GetRealNamedProperty(key));
+}
+
+NAN_INLINE MaybeLocal<v8::Value> CallAsFunction(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::Object> recv
+  , int argc
+  , v8::Handle<v8::Value> argv[]) {
+  return MaybeLocal<v8::Value>(obj->CallAsFunction(recv, argc, argv));
+}
+
+NAN_INLINE MaybeLocal<v8::Value> CallAsConstructor(
+    v8::Handle<v8::Object> obj
+  , int argc
+  , v8::Local<v8::Value> argv[]) {
+  return MaybeLocal<v8::Value>(obj->CallAsConstructor(argc, argv));
+}
+
+NAN_INLINE
+MaybeLocal<v8::String> GetSourceLine(v8::Handle<v8::Message> msg) {
+  return MaybeLocal<v8::String>(msg->GetSourceLine());
+}
+
+NAN_INLINE Maybe<int> GetLineNumber(v8::Handle<v8::Message> msg) {
+  return Just<int>(msg->GetLineNumber());
+}
+
+NAN_INLINE Maybe<int> GetStartColumn(v8::Handle<v8::Message> msg) {
+  return Just<int>(msg->GetStartColumn());
+}
+
+NAN_INLINE Maybe<int> GetEndColumn(v8::Handle<v8::Message> msg) {
+  return Just<int>(msg->GetEndColumn());
+}
+
+NAN_INLINE MaybeLocal<v8::Object> CloneElementAt(
+    v8::Handle<v8::Array> array
+  , uint32_t index) {
+  return MaybeLocal<v8::Object>(array->CloneElementAt(index));
+}
+
+#endif  // NAN_MAYBE_PRE_43_INL_H_

--- a/deps/nan/nan_new.h
+++ b/deps/nan/nan_new.h
@@ -1,0 +1,340 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2015 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+#ifndef NAN_NEW_H_
+#define NAN_NEW_H_
+
+namespace imp {  // scnr
+
+// TODO(agnat): Generalize
+template <typename T> v8::Local<T> To(v8::Local<v8::Integer> i);
+
+template <>
+inline
+v8::Local<v8::Integer>
+To<v8::Integer>(v8::Local<v8::Integer> i) {
+  return Nan::To<v8::Integer>(i).ToLocalChecked();
+}
+
+template <>
+inline
+v8::Local<v8::Int32>
+To<v8::Int32>(v8::Local<v8::Integer> i) {
+  return Nan::To<v8::Int32>(i).ToLocalChecked();
+}
+
+template <>
+inline
+v8::Local<v8::Uint32>
+To<v8::Uint32>(v8::Local<v8::Integer> i) {
+  return Nan::To<v8::Uint32>(i).ToLocalChecked();
+}
+
+template <typename T> struct FactoryBase {
+  typedef v8::Local<T> return_t;
+};
+
+template <typename T> struct MaybeFactoryBase {
+  typedef MaybeLocal<T> return_t;
+};
+
+template <typename T> struct Factory;
+
+template <>
+struct Factory<v8::Array> : FactoryBase<v8::Array> {
+  static inline return_t New();
+  static inline return_t New(int length);
+};
+
+template <>
+struct Factory<v8::Boolean> : FactoryBase<v8::Boolean> {
+  static inline return_t New(bool value);
+};
+
+template <>
+struct Factory<v8::BooleanObject> : FactoryBase<v8::BooleanObject> {
+  static inline return_t New(bool value);
+};
+
+template <>
+struct Factory<v8::Context> : FactoryBase<v8::Context> {
+  static inline
+  return_t
+  New( v8::ExtensionConfiguration* extensions = NULL
+     , v8::Local<v8::ObjectTemplate> tmpl = v8::Local<v8::ObjectTemplate>()
+     , v8::Local<v8::Value> obj = v8::Local<v8::Value>());
+};
+
+template <>
+struct Factory<v8::Date> : MaybeFactoryBase<v8::Date> {
+  static inline return_t New(double value);
+};
+
+template <>
+struct Factory<v8::External> : FactoryBase<v8::External> {
+  static inline return_t New(void *value);
+};
+
+template <>
+struct Factory<v8::Function> : FactoryBase<v8::Function> {
+  static inline
+  return_t
+  New( FunctionCallback callback
+     , v8::Local<v8::Value> data = v8::Local<v8::Value>());
+};
+
+template <>
+struct Factory<v8::FunctionTemplate> : FactoryBase<v8::FunctionTemplate> {
+  static inline
+  return_t
+  New( FunctionCallback callback = NULL
+     , v8::Local<v8::Value> data = v8::Local<v8::Value>()
+     , v8::Local<v8::Signature> signature = v8::Local<v8::Signature>());
+};
+
+template <>
+struct Factory<v8::Number> : FactoryBase<v8::Number> {
+  static inline return_t New(double value);
+};
+
+template <>
+struct Factory<v8::NumberObject> : FactoryBase<v8::NumberObject> {
+  static inline return_t New(double value);
+};
+
+template <typename T>
+struct IntegerFactory : FactoryBase<T> {
+  typedef typename FactoryBase<T>::return_t return_t;
+  static inline return_t New(int32_t value);
+  static inline return_t New(uint32_t value);
+};
+
+template <>
+struct Factory<v8::Integer> : IntegerFactory<v8::Integer> {};
+
+template <>
+struct Factory<v8::Int32> : IntegerFactory<v8::Int32> {};
+
+template <>
+struct Factory<v8::Uint32> : FactoryBase<v8::Uint32> {
+  static inline return_t New(int32_t value);
+  static inline return_t New(uint32_t value);
+};
+
+template <>
+struct Factory<v8::Object> : FactoryBase<v8::Object> {
+  static inline return_t New();
+};
+
+template <>
+struct Factory<v8::ObjectTemplate> : FactoryBase<v8::ObjectTemplate> {
+  static inline return_t New();
+};
+
+template <>
+struct Factory<v8::RegExp> : MaybeFactoryBase<v8::RegExp> {
+  static inline return_t New(
+      v8::Local<v8::String> pattern, v8::RegExp::Flags flags);
+};
+
+template <>
+struct Factory<v8::Script> : MaybeFactoryBase<v8::Script> {
+  static inline return_t New( v8::Local<v8::String> source);
+  static inline return_t New( v8::Local<v8::String> source
+                            , v8::ScriptOrigin const& origin);
+};
+
+template <>
+struct Factory<v8::Signature> : FactoryBase<v8::Signature> {
+  typedef v8::Local<v8::FunctionTemplate> FTH;
+  static inline return_t New(FTH receiver = FTH());
+};
+
+template <>
+struct Factory<v8::String> : MaybeFactoryBase<v8::String> {
+  static inline return_t New();
+  static inline return_t New(const char *value, int length = -1);
+  static inline return_t New(const uint16_t *value, int length = -1);
+  static inline return_t New(std::string const& value);
+
+  static inline return_t New(v8::String::ExternalStringResource * value);
+  static inline return_t New(ExternalOneByteStringResource * value);
+};
+
+template <>
+struct Factory<v8::StringObject> : FactoryBase<v8::StringObject> {
+  static inline return_t New(v8::Local<v8::String> value);
+};
+
+}  // end of namespace imp
+
+#if (NODE_MODULE_VERSION >= 12)
+
+namespace imp {
+
+template <>
+struct Factory<v8::UnboundScript> : MaybeFactoryBase<v8::UnboundScript> {
+  static inline return_t New( v8::Local<v8::String> source);
+  static inline return_t New( v8::Local<v8::String> source
+                            , v8::ScriptOrigin const& origin);
+};
+
+}  // end of namespace imp
+
+# include "nan_implementation_12_inl.h"
+
+#else  // NODE_MODULE_VERSION >= 12
+
+# include "nan_implementation_pre_12_inl.h"
+
+#endif
+
+//=== API ======================================================================
+
+template <typename T>
+typename imp::Factory<T>::return_t
+New() {
+  return imp::Factory<T>::New();
+}
+
+template <typename T, typename A0>
+typename imp::Factory<T>::return_t
+New(A0 arg0) {
+  return imp::Factory<T>::New(arg0);
+}
+
+template <typename T, typename A0, typename A1>
+typename imp::Factory<T>::return_t
+New(A0 arg0, A1 arg1) {
+  return imp::Factory<T>::New(arg0, arg1);
+}
+
+template <typename T, typename A0, typename A1, typename A2>
+typename imp::Factory<T>::return_t
+New(A0 arg0, A1 arg1, A2 arg2) {
+  return imp::Factory<T>::New(arg0, arg1, arg2);
+}
+
+template <typename T, typename A0, typename A1, typename A2, typename A3>
+typename imp::Factory<T>::return_t
+New(A0 arg0, A1 arg1, A2 arg2, A3 arg3) {
+  return imp::Factory<T>::New(arg0, arg1, arg2, arg3);
+}
+
+// Note(agnat): When passing overloaded function pointers to template functions
+// as generic arguments the compiler needs help in picking the right overload.
+// These two functions handle New<Function> and New<FunctionTemplate> with
+// all argument variations.
+
+// v8::Function and v8::FunctionTemplate with one or two arguments
+template <typename T>
+typename imp::Factory<T>::return_t
+New( FunctionCallback callback
+      , v8::Local<v8::Value> data = v8::Local<v8::Value>()) {
+    return imp::Factory<T>::New(callback, data);
+}
+
+// v8::Function and v8::FunctionTemplate with three arguments
+template <typename T, typename A2>
+typename imp::Factory<T>::return_t
+New( FunctionCallback callback
+      , v8::Local<v8::Value> data = v8::Local<v8::Value>()
+      , A2 a2 = A2()) {
+    return imp::Factory<T>::New(callback, data, a2);
+}
+
+// Convenience
+
+#if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
+template <typename T> inline v8::Local<T> New(v8::Handle<T> h);
+#endif
+
+#if NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION
+template <typename T, typename M>
+    inline v8::Local<T> New(v8::Persistent<T, M> const& p);
+#else
+template <typename T> inline v8::Local<T> New(v8::Persistent<T> const& p);
+#endif
+template <typename T, typename M>
+inline v8::Local<T> New(Persistent<T, M> const& p);
+template <typename T>
+inline v8::Local<T> New(Global<T> const& p);
+
+inline
+imp::Factory<v8::Boolean>::return_t
+New(bool value) {
+  return New<v8::Boolean>(value);
+}
+
+inline
+imp::Factory<v8::Int32>::return_t
+New(int32_t value) {
+  return New<v8::Int32>(value);
+}
+
+inline
+imp::Factory<v8::Uint32>::return_t
+New(uint32_t value) {
+  return New<v8::Uint32>(value);
+}
+
+inline
+imp::Factory<v8::Number>::return_t
+New(double value) {
+  return New<v8::Number>(value);
+}
+
+inline
+imp::Factory<v8::String>::return_t
+New(std::string const& value) {  // NOLINT(build/include_what_you_use)
+  return New<v8::String>(value);
+}
+
+inline
+imp::Factory<v8::String>::return_t
+New(const char * value, int length) {
+  return New<v8::String>(value, length);
+}
+
+inline
+imp::Factory<v8::String>::return_t
+New(const uint16_t * value, int length) {
+  return New<v8::String>(value, length);
+}
+
+inline
+imp::Factory<v8::String>::return_t
+New(const char * value) {
+  return New<v8::String>(value);
+}
+
+inline
+imp::Factory<v8::String>::return_t
+New(const uint16_t * value) {
+  return New<v8::String>(value);
+}
+
+inline
+imp::Factory<v8::String>::return_t
+New(v8::String::ExternalStringResource * value) {
+  return New<v8::String>(value);
+}
+
+inline
+imp::Factory<v8::String>::return_t
+New(ExternalOneByteStringResource * value) {
+  return New<v8::String>(value);
+}
+
+inline
+imp::Factory<v8::RegExp>::return_t
+New(v8::Local<v8::String> pattern, v8::RegExp::Flags flags) {
+  return New<v8::RegExp>(pattern, flags);
+}
+
+#endif  // NAN_NEW_H_

--- a/deps/nan/nan_object_wrap.h
+++ b/deps/nan/nan_object_wrap.h
@@ -1,0 +1,155 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2015 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+#ifndef NAN_OBJECT_WRAP_H_
+#define NAN_OBJECT_WRAP_H_
+
+class ObjectWrap {
+ public:
+  ObjectWrap() {
+    refs_ = 0;
+  }
+
+
+  virtual ~ObjectWrap() {
+    if (persistent().IsEmpty()) {
+      return;
+    }
+
+    assert(persistent().IsNearDeath());
+    persistent().ClearWeak();
+    persistent().Reset();
+  }
+
+
+  template <class T>
+  static inline T* Unwrap(v8::Local<v8::Object> object) {
+    assert(!object.IsEmpty());
+    assert(object->InternalFieldCount() > 0);
+    // Cast to ObjectWrap before casting to T.  A direct cast from void
+    // to T won't work right when T has more than one base class.
+    void* ptr = GetInternalFieldPointer(object, 0);
+    ObjectWrap* wrap = static_cast<ObjectWrap*>(ptr);
+    return static_cast<T*>(wrap);
+  }
+
+
+  inline v8::Local<v8::Object> handle() {
+    return New(persistent());
+  }
+
+
+  inline Persistent<v8::Object>& persistent() {
+    return handle_;
+  }
+
+
+ protected:
+  inline void Wrap(v8::Local<v8::Object> object) {
+    assert(persistent().IsEmpty());
+    assert(object->InternalFieldCount() > 0);
+    SetInternalFieldPointer(object, 0, this);
+    persistent().Reset(object);
+    MakeWeak();
+  }
+
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
+  (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
+
+  inline void MakeWeak() {
+    persistent().v8::PersistentBase<v8::Object>::SetWeak(
+        this, WeakCallback, v8::WeakCallbackType::kParameter);
+    persistent().MarkIndependent();
+  }
+
+#elif NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION
+
+  inline void MakeWeak() {
+    persistent().v8::PersistentBase<v8::Object>::SetWeak(this, WeakCallback);
+    persistent().MarkIndependent();
+  }
+
+#else
+
+  inline void MakeWeak() {
+    persistent().persistent.MakeWeak(this, WeakCallback);
+    persistent().MarkIndependent();
+  }
+
+#endif
+
+  /* Ref() marks the object as being attached to an event loop.
+   * Refed objects will not be garbage collected, even if
+   * all references are lost.
+   */
+  virtual void Ref() {
+    assert(!persistent().IsEmpty());
+    persistent().ClearWeak();
+    refs_++;
+  }
+
+  /* Unref() marks an object as detached from the event loop.  This is its
+   * default state.  When an object with a "weak" reference changes from
+   * attached to detached state it will be freed. Be careful not to access
+   * the object after making this call as it might be gone!
+   * (A "weak reference" means an object that only has a
+   * persistant handle.)
+   *
+   * DO NOT CALL THIS FROM DESTRUCTOR
+   */
+  virtual void Unref() {
+    assert(!persistent().IsEmpty());
+    assert(!persistent().IsWeak());
+    assert(refs_ > 0);
+    if (--refs_ == 0)
+      MakeWeak();
+  }
+
+  int refs_;  // ro
+
+ private:
+  NAN_DISALLOW_ASSIGN_COPY_MOVE(ObjectWrap)
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
+  (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
+
+  static void
+  WeakCallback(v8::WeakCallbackInfo<ObjectWrap> const& info) {
+    ObjectWrap* wrap = info.GetParameter();
+    assert(wrap->refs_ == 0);
+    assert(wrap->handle_.IsNearDeath());
+    wrap->handle_.Reset();
+    delete wrap;
+  }
+
+#elif NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION
+
+  static void
+  WeakCallback(v8::WeakCallbackData<v8::Object, ObjectWrap> const& data) {
+    ObjectWrap* wrap = data.GetParameter();
+    assert(wrap->refs_ == 0);
+    assert(wrap->handle_.IsNearDeath());
+    wrap->handle_.Reset();
+    delete wrap;
+  }
+
+#else
+
+  static void WeakCallback(v8::Persistent<v8::Value> value, void *data) {
+    ObjectWrap *wrap = static_cast<ObjectWrap*>(data);
+    assert(wrap->refs_ == 0);
+    assert(wrap->handle_.IsNearDeath());
+    wrap->handle_.Reset();
+    delete wrap;
+  }
+
+#endif
+  Persistent<v8::Object> handle_;
+};
+
+
+#endif  // NAN_OBJECT_WRAP_H_

--- a/deps/nan/nan_persistent_12_inl.h
+++ b/deps/nan/nan_persistent_12_inl.h
@@ -1,0 +1,129 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2015 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+#ifndef NAN_PERSISTENT_12_INL_H_
+#define NAN_PERSISTENT_12_INL_H_
+
+template<typename T, typename M> class Persistent :
+    public v8::Persistent<T, M> {
+ public:
+  NAN_INLINE Persistent() : v8::Persistent<T, M>() {}
+
+  template<typename S> NAN_INLINE Persistent(v8::Local<S> that) :
+      v8::Persistent<T, M>(v8::Isolate::GetCurrent(), that) {}
+
+  template<typename S, typename M2>
+  NAN_INLINE Persistent(const v8::Persistent<S, M2> &that) :
+      v8::Persistent<T, M2>(v8::Isolate::GetCurrent(), that) {}
+
+  NAN_INLINE void Reset() { v8::PersistentBase<T>::Reset(); }
+
+  template <typename S>
+  NAN_INLINE void Reset(const v8::Local<S> &other) {
+    v8::PersistentBase<T>::Reset(v8::Isolate::GetCurrent(), other);
+  }
+
+  template <typename S>
+  NAN_INLINE void Reset(const v8::PersistentBase<S> &other) {
+    v8::PersistentBase<T>::Reset(v8::Isolate::GetCurrent(), other);
+  }
+
+  template<typename P>
+  NAN_INLINE void SetWeak(
+    P *parameter
+    , typename WeakCallbackInfo<P>::Callback callback
+    , WeakCallbackType type);
+
+ private:
+  NAN_INLINE T *operator*() const { return *PersistentBase<T>::persistent; }
+
+  template<typename S, typename M2>
+  NAN_INLINE void Copy(const Persistent<S, M2> &that) {
+    TYPE_CHECK(T, S);
+
+    this->Reset();
+
+    if (!that.IsEmpty()) {
+      this->Reset(that);
+      M::Copy(that, this);
+    }
+  }
+};
+
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
+  (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
+template<typename T>
+class Global : public v8::Global<T> {
+ public:
+  NAN_INLINE Global() : v8::Global<T>() {}
+
+  template<typename S> NAN_INLINE Global(v8::Local<S> that) :
+    v8::Global<T>(v8::Isolate::GetCurrent(), that) {}
+
+  template<typename S>
+  NAN_INLINE Global(const v8::PersistentBase<S> &that) :
+      v8::Global<S>(v8::Isolate::GetCurrent(), that) {}
+
+  NAN_INLINE void Reset() { v8::PersistentBase<T>::Reset(); }
+
+  template <typename S>
+  NAN_INLINE void Reset(const v8::Local<S> &other) {
+    v8::PersistentBase<T>::Reset(v8::Isolate::GetCurrent(), other);
+  }
+
+  template <typename S>
+  NAN_INLINE void Reset(const v8::PersistentBase<S> &other) {
+    v8::PersistentBase<T>::Reset(v8::Isolate::GetCurrent(), other);
+  }
+
+  template<typename P>
+  NAN_INLINE void SetWeak(
+    P *parameter
+    , typename WeakCallbackInfo<P>::Callback callback
+    , WeakCallbackType type) {
+    reinterpret_cast<Persistent<T>*>(this)->SetWeak(
+        parameter, callback, type);
+  }
+};
+#else
+template<typename T>
+class Global : public v8::UniquePersistent<T> {
+ public:
+  NAN_INLINE Global() : v8::UniquePersistent<T>() {}
+
+  template<typename S> NAN_INLINE Global(v8::Local<S> that) :
+    v8::UniquePersistent<T>(v8::Isolate::GetCurrent(), that) {}
+
+  template<typename S>
+  NAN_INLINE Global(const v8::PersistentBase<S> &that) :
+      v8::UniquePersistent<S>(v8::Isolate::GetCurrent(), that) {}
+
+  NAN_INLINE void Reset() { v8::PersistentBase<T>::Reset(); }
+
+  template <typename S>
+  NAN_INLINE void Reset(const v8::Local<S> &other) {
+    v8::PersistentBase<T>::Reset(v8::Isolate::GetCurrent(), other);
+  }
+
+  template <typename S>
+  NAN_INLINE void Reset(const v8::PersistentBase<S> &other) {
+    v8::PersistentBase<T>::Reset(v8::Isolate::GetCurrent(), other);
+  }
+
+  template<typename P>
+  NAN_INLINE void SetWeak(
+    P *parameter
+    , typename WeakCallbackInfo<P>::Callback callback
+    , WeakCallbackType type) {
+    reinterpret_cast<Persistent<T>*>(this)->SetWeak(
+        parameter, callback, type);
+  }
+};
+#endif
+
+#endif  // NAN_PERSISTENT_12_INL_H_

--- a/deps/nan/nan_persistent_pre_12_inl.h
+++ b/deps/nan/nan_persistent_pre_12_inl.h
@@ -1,0 +1,242 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2015 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+#ifndef NAN_PERSISTENT_PRE_12_INL_H_
+#define NAN_PERSISTENT_PRE_12_INL_H_
+
+template<typename T>
+class PersistentBase {
+  v8::Persistent<T> persistent;
+  template<typename U>
+  friend v8::Local<U> New(const PersistentBase<U> &p);
+  template<typename U, typename M>
+  friend v8::Local<U> New(const Persistent<U, M> &p);
+  template<typename U>
+  friend v8::Local<U> New(const Global<U> &p);
+  template<typename S> friend class ReturnValue;
+
+ public:
+  NAN_INLINE PersistentBase() :
+      persistent() {}
+
+  NAN_INLINE void Reset() {
+    persistent.Dispose();
+    persistent.Clear();
+  }
+
+  template<typename S>
+  NAN_INLINE void Reset(const v8::Local<S> &other) {
+    TYPE_CHECK(T, S);
+
+    if (!persistent.IsEmpty()) {
+      persistent.Dispose();
+    }
+
+    if (other.IsEmpty()) {
+      persistent.Clear();
+    } else {
+      persistent = v8::Persistent<T>::New(other);
+    }
+  }
+
+  template<typename S>
+  NAN_INLINE void Reset(const PersistentBase<S> &other) {
+    TYPE_CHECK(T, S);
+
+    if (!persistent.IsEmpty()) {
+      persistent.Dispose();
+    }
+
+    if (other.IsEmpty()) {
+      persistent.Clear();
+    } else {
+      persistent = v8::Persistent<T>::New(other.persistent);
+    }
+  }
+
+  NAN_INLINE bool IsEmpty() const { return persistent.IsEmpty(); }
+
+  NAN_INLINE void Empty() { persistent.Clear(); }
+
+  template<typename S>
+  NAN_INLINE bool operator==(const PersistentBase<S> &that) {
+    return this->persistent == that.persistent;
+  }
+
+  template<typename S>
+  NAN_INLINE bool operator==(const v8::Local<S> &that) {
+    return this->persistent == that;
+  }
+
+  template<typename S>
+  NAN_INLINE bool operator!=(const PersistentBase<S> &that) {
+    return !operator==(that);
+  }
+
+  template<typename S>
+  NAN_INLINE bool operator!=(const v8::Local<S> &that) {
+    return !operator==(that);
+  }
+
+  template<typename P>
+  NAN_INLINE void SetWeak(
+    P *parameter
+    , typename WeakCallbackInfo<P>::Callback callback
+    , WeakCallbackType type);
+
+  NAN_INLINE void ClearWeak() { persistent.ClearWeak(); }
+
+  NAN_INLINE void MarkIndependent() { persistent.MarkIndependent(); }
+
+  NAN_INLINE bool IsIndependent() const { return persistent.IsIndependent(); }
+
+  NAN_INLINE bool IsNearDeath() const { return persistent.IsNearDeath(); }
+
+  NAN_INLINE bool IsWeak() const { return persistent.IsWeak(); }
+
+ private:
+  NAN_INLINE explicit PersistentBase(v8::Persistent<T> that) :
+      persistent(that) { }
+  NAN_INLINE explicit PersistentBase(T *val) : persistent(val) {}
+  template<typename S, typename M> friend class Persistent;
+  template<typename S> friend class Global;
+  friend class ObjectWrap;
+};
+
+template<typename T>
+class NonCopyablePersistentTraits {
+ public:
+  typedef Persistent<T, NonCopyablePersistentTraits<T> >
+      NonCopyablePersistent;
+  static const bool kResetInDestructor = false;
+  template<typename S, typename M>
+  NAN_INLINE static void Copy(const Persistent<S, M> &source,
+                             NonCopyablePersistent *dest) {
+    Uncompilable<v8::Object>();
+  }
+
+  template<typename O> NAN_INLINE static void Uncompilable() {
+    TYPE_CHECK(O, v8::Primitive);
+  }
+};
+
+template<typename T>
+struct CopyablePersistentTraits {
+  typedef Persistent<T, CopyablePersistentTraits<T> > CopyablePersistent;
+  static const bool kResetInDestructor = true;
+  template<typename S, typename M>
+  static NAN_INLINE void Copy(const Persistent<S, M> &source,
+                             CopyablePersistent *dest) {}
+};
+
+template<typename T, typename M> class Persistent :
+    public PersistentBase<T> {
+ public:
+  NAN_INLINE Persistent() {}
+
+  template<typename S> NAN_INLINE Persistent(v8::Handle<S> that)
+      : PersistentBase<T>(v8::Persistent<T>::New(that)) {
+    TYPE_CHECK(T, S);
+  }
+
+  NAN_INLINE Persistent(const Persistent &that) : PersistentBase<T>() {
+    Copy(that);
+  }
+
+  template<typename S, typename M2>
+  NAN_INLINE Persistent(const Persistent<S, M2> &that) :
+      PersistentBase<T>() {
+    Copy(that);
+  }
+
+  NAN_INLINE Persistent &operator=(const Persistent &that) {
+    Copy(that);
+    return *this;
+  }
+
+  template <class S, class M2>
+  NAN_INLINE Persistent &operator=(const Persistent<S, M2> &that) {
+    Copy(that);
+    return *this;
+  }
+
+  NAN_INLINE ~Persistent() {
+    if (M::kResetInDestructor) this->Reset();
+  }
+
+ private:
+  NAN_INLINE T *operator*() const { return *PersistentBase<T>::persistent; }
+
+  template<typename S, typename M2>
+  NAN_INLINE void Copy(const Persistent<S, M2> &that) {
+    TYPE_CHECK(T, S);
+
+    this->Reset();
+
+    if (!that.IsEmpty()) {
+      this->persistent = v8::Persistent<T>::New(that.persistent);
+      M::Copy(that, this);
+    }
+  }
+};
+
+template<typename T>
+class Global : public PersistentBase<T> {
+  struct RValue {
+    NAN_INLINE explicit RValue(Global* obj) : object(obj) {}
+    Global* object;
+  };
+
+ public:
+  NAN_INLINE Global() : PersistentBase<T>(0) { }
+
+  template <typename S>
+  NAN_INLINE Global(v8::Local<S> that)
+      : PersistentBase<T>(v8::Persistent<T>::New(that)) {
+    TYPE_CHECK(T, S);
+  }
+
+  template <typename S>
+  NAN_INLINE Global(const PersistentBase<S> &that)
+    : PersistentBase<T>(that) {
+    TYPE_CHECK(T, S);
+  }
+  /**
+   * Move constructor.
+   */
+  NAN_INLINE Global(RValue rvalue)
+    : PersistentBase<T>(rvalue.object.persistent) {
+    rvalue.object->Reset();
+  }
+  NAN_INLINE ~Global() { this->Reset(); }
+  /**
+   * Move via assignment.
+   */
+  template<typename S>
+  NAN_INLINE Global &operator=(Global<S> rhs) {
+    TYPE_CHECK(T, S);
+    this->Reset(rhs.persistent);
+    rhs.Reset();
+    return *this;
+  }
+  /**
+   * Cast operator for moves.
+   */
+  NAN_INLINE operator RValue() { return RValue(this); }
+  /**
+   * Pass allows returning uniques from functions, etc.
+   */
+  Global Pass() { return Global(RValue(this)); }
+
+ private:
+  Global(Global &);
+  void operator=(Global &);
+  template<typename S> friend class ReturnValue;
+};
+
+#endif  // NAN_PERSISTENT_PRE_12_INL_H_

--- a/deps/nan/nan_string_bytes.h
+++ b/deps/nan/nan_string_bytes.h
@@ -1,0 +1,305 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#ifndef NAN_STRING_BYTES_H_
+#define NAN_STRING_BYTES_H_
+
+// Decodes a v8::Local<v8::String> or Buffer to a raw char*
+
+namespace imp {
+
+using v8::Local;
+using v8::Object;
+using v8::String;
+using v8::Value;
+
+
+//// Base 64 ////
+
+#define base64_encoded_size(size) ((size + 2 - ((size + 2) % 3)) / 3 * 4)
+
+
+
+//// HEX ////
+
+static bool contains_non_ascii_slow(const char* buf, size_t len) {
+  for (size_t i = 0; i < len; ++i) {
+    if (buf[i] & 0x80) return true;
+  }
+  return false;
+}
+
+
+static bool contains_non_ascii(const char* src, size_t len) {
+  if (len < 16) {
+    return contains_non_ascii_slow(src, len);
+  }
+
+  const unsigned bytes_per_word = sizeof(void*);
+  const unsigned align_mask = bytes_per_word - 1;
+  const unsigned unaligned = reinterpret_cast<uintptr_t>(src) & align_mask;
+
+  if (unaligned > 0) {
+    const unsigned n = bytes_per_word - unaligned;
+    if (contains_non_ascii_slow(src, n)) return true;
+    src += n;
+    len -= n;
+  }
+
+
+#if defined(__x86_64__) || defined(_WIN64)
+  const uintptr_t mask = 0x8080808080808080ll;
+#else
+  const uintptr_t mask = 0x80808080l;
+#endif
+
+  const uintptr_t* srcw = reinterpret_cast<const uintptr_t*>(src);
+
+  for (size_t i = 0, n = len / bytes_per_word; i < n; ++i) {
+    if (srcw[i] & mask) return true;
+  }
+
+  const unsigned remainder = len & align_mask;
+  if (remainder > 0) {
+    const size_t offset = len - remainder;
+    if (contains_non_ascii_slow(src + offset, remainder)) return true;
+  }
+
+  return false;
+}
+
+
+static void force_ascii_slow(const char* src, char* dst, size_t len) {
+  for (size_t i = 0; i < len; ++i) {
+    dst[i] = src[i] & 0x7f;
+  }
+}
+
+
+static void force_ascii(const char* src, char* dst, size_t len) {
+  if (len < 16) {
+    force_ascii_slow(src, dst, len);
+    return;
+  }
+
+  const unsigned bytes_per_word = sizeof(void*);
+  const unsigned align_mask = bytes_per_word - 1;
+  const unsigned src_unalign = reinterpret_cast<uintptr_t>(src) & align_mask;
+  const unsigned dst_unalign = reinterpret_cast<uintptr_t>(dst) & align_mask;
+
+  if (src_unalign > 0) {
+    if (src_unalign == dst_unalign) {
+      const unsigned unalign = bytes_per_word - src_unalign;
+      force_ascii_slow(src, dst, unalign);
+      src += unalign;
+      dst += unalign;
+      len -= src_unalign;
+    } else {
+      force_ascii_slow(src, dst, len);
+      return;
+    }
+  }
+
+#if defined(__x86_64__) || defined(_WIN64)
+  const uintptr_t mask = ~0x8080808080808080ll;
+#else
+  const uintptr_t mask = ~0x80808080l;
+#endif
+
+  const uintptr_t* srcw = reinterpret_cast<const uintptr_t*>(src);
+  uintptr_t* dstw = reinterpret_cast<uintptr_t*>(dst);
+
+  for (size_t i = 0, n = len / bytes_per_word; i < n; ++i) {
+    dstw[i] = srcw[i] & mask;
+  }
+
+  const unsigned remainder = len & align_mask;
+  if (remainder > 0) {
+    const size_t offset = len - remainder;
+    force_ascii_slow(src + offset, dst + offset, remainder);
+  }
+}
+
+
+static size_t base64_encode(const char* src,
+                            size_t slen,
+                            char* dst,
+                            size_t dlen) {
+  // We know how much we'll write, just make sure that there's space.
+  assert(dlen >= base64_encoded_size(slen) &&
+      "not enough space provided for base64 encode");
+
+  dlen = base64_encoded_size(slen);
+
+  unsigned a;
+  unsigned b;
+  unsigned c;
+  unsigned i;
+  unsigned k;
+  unsigned n;
+
+  static const char table[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                              "abcdefghijklmnopqrstuvwxyz"
+                              "0123456789+/";
+
+  i = 0;
+  k = 0;
+  n = slen / 3 * 3;
+
+  while (i < n) {
+    a = src[i + 0] & 0xff;
+    b = src[i + 1] & 0xff;
+    c = src[i + 2] & 0xff;
+
+    dst[k + 0] = table[a >> 2];
+    dst[k + 1] = table[((a & 3) << 4) | (b >> 4)];
+    dst[k + 2] = table[((b & 0x0f) << 2) | (c >> 6)];
+    dst[k + 3] = table[c & 0x3f];
+
+    i += 3;
+    k += 4;
+  }
+
+  if (n != slen) {
+    switch (slen - n) {
+      case 1:
+        a = src[i + 0] & 0xff;
+        dst[k + 0] = table[a >> 2];
+        dst[k + 1] = table[(a & 3) << 4];
+        dst[k + 2] = '=';
+        dst[k + 3] = '=';
+        break;
+
+      case 2:
+        a = src[i + 0] & 0xff;
+        b = src[i + 1] & 0xff;
+        dst[k + 0] = table[a >> 2];
+        dst[k + 1] = table[((a & 3) << 4) | (b >> 4)];
+        dst[k + 2] = table[(b & 0x0f) << 2];
+        dst[k + 3] = '=';
+        break;
+    }
+  }
+
+  return dlen;
+}
+
+
+static size_t hex_encode(const char* src, size_t slen, char* dst, size_t dlen) {
+  // We know how much we'll write, just make sure that there's space.
+  assert(dlen >= slen * 2 &&
+      "not enough space provided for hex encode");
+
+  dlen = slen * 2;
+  for (uint32_t i = 0, k = 0; k < dlen; i += 1, k += 2) {
+    static const char hex[] = "0123456789abcdef";
+    uint8_t val = static_cast<uint8_t>(src[i]);
+    dst[k + 0] = hex[val >> 4];
+    dst[k + 1] = hex[val & 15];
+  }
+
+  return dlen;
+}
+
+
+
+static Local<Value> Encode(const char* buf,
+                           size_t buflen,
+                           enum Encoding encoding) {
+  assert(buflen <= node::Buffer::kMaxLength);
+  if (!buflen && encoding != BUFFER)
+    return New("").ToLocalChecked();
+
+  Local<String> val;
+  switch (encoding) {
+    case BUFFER:
+      return CopyBuffer(buf, buflen).ToLocalChecked();
+
+    case ASCII:
+      if (contains_non_ascii(buf, buflen)) {
+        char* out = new char[buflen];
+        force_ascii(buf, out, buflen);
+        val = New<String>(out, buflen).ToLocalChecked();
+        delete[] out;
+      } else {
+        val = New<String>(buf, buflen).ToLocalChecked();
+      }
+      break;
+
+    case UTF8:
+      val = New<String>(buf, buflen).ToLocalChecked();
+      break;
+
+    case BINARY: {
+      // TODO(isaacs) use ExternalTwoByteString?
+      const unsigned char *cbuf = reinterpret_cast<const unsigned char*>(buf);
+      uint16_t * twobytebuf = new uint16_t[buflen];
+      for (size_t i = 0; i < buflen; i++) {
+        // XXX is the following line platform independent?
+        twobytebuf[i] = cbuf[i];
+      }
+      val = New<String>(twobytebuf, buflen).ToLocalChecked();
+      delete[] twobytebuf;
+      break;
+    }
+
+    case BASE64: {
+      size_t dlen = base64_encoded_size(buflen);
+      char* dst = new char[dlen];
+
+      size_t written = base64_encode(buf, buflen, dst, dlen);
+      assert(written == dlen);
+
+      val = New<String>(dst, dlen).ToLocalChecked();
+      delete[] dst;
+      break;
+    }
+
+    case UCS2: {
+      const uint16_t* data = reinterpret_cast<const uint16_t*>(buf);
+      val = New<String>(data, buflen / 2).ToLocalChecked();
+      break;
+    }
+
+    case HEX: {
+      size_t dlen = buflen * 2;
+      char* dst = new char[dlen];
+      size_t written = hex_encode(buf, buflen, dst, dlen);
+      assert(written == dlen);
+
+      val = New<String>(dst, dlen).ToLocalChecked();
+      delete[] dst;
+      break;
+    }
+
+    default:
+      assert(0 && "unknown encoding");
+      break;
+  }
+
+  return val;
+}
+
+#undef base64_encoded_size
+
+}  // end of namespace imp
+
+#endif  // NAN_STRING_BYTES_H_

--- a/deps/nan/nan_typedarray_contents.h
+++ b/deps/nan/nan_typedarray_contents.h
@@ -1,0 +1,87 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2015 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+#ifndef NAN_TYPEDARRAY_CONTENTS_H_
+#define NAN_TYPEDARRAY_CONTENTS_H_
+
+template<typename T>
+class TypedArrayContents {
+ public:
+  NAN_INLINE explicit TypedArrayContents(v8::Local<v8::Value> from) :
+      length_(0), data_(NULL) {
+
+    size_t length = 0;
+    void*  data = NULL;
+
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
+  (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
+
+    if (from->IsArrayBufferView()) {
+      v8::Local<v8::ArrayBufferView> array =
+        v8::Local<v8::ArrayBufferView>::Cast(from);
+
+      const size_t    byte_length = array->ByteLength();
+      const ptrdiff_t byte_offset = array->ByteOffset();
+      v8::Local<v8::ArrayBuffer> buffer = array->Buffer();
+
+      length = byte_length / sizeof(T);
+      data   = static_cast<char*>(buffer->GetContents().Data()) + byte_offset;
+    }
+
+#else
+
+    if (from->IsObject() && !from->IsNull()) {
+      v8::Local<v8::Object> array = v8::Local<v8::Object>::Cast(from);
+
+      MaybeLocal<v8::Value> buffer = Get(array,
+        New<v8::String>("buffer").ToLocalChecked());
+      MaybeLocal<v8::Value> byte_length = Get(array,
+        New<v8::String>("byteLength").ToLocalChecked());
+      MaybeLocal<v8::Value> byte_offset = Get(array,
+        New<v8::String>("byteOffset").ToLocalChecked());
+
+      if (!buffer.IsEmpty() &&
+          !byte_length.IsEmpty() && byte_length.ToLocalChecked()->IsUint32() &&
+          !byte_offset.IsEmpty() && byte_offset.ToLocalChecked()->IsUint32()) {
+        data = array->GetIndexedPropertiesExternalArrayData();
+        if(data) {
+          length = byte_length.ToLocalChecked()->Uint32Value() / sizeof(T);
+        }
+      }
+    }
+
+#endif
+
+#if defined(_MSC_VER) || defined(__GNUC__)
+    assert(reinterpret_cast<uintptr_t>(data) % __alignof(T) == 0);
+#elif __cplusplus >= 201103L
+    assert(reinterpret_cast<uintptr_t>(data) % alignof(T) == 0);
+#else
+    assert(reinterpret_cast<uintptr_t>(data) % sizeof(T) == 0);
+#endif
+
+    length_ = length;
+    data_   = static_cast<T*>(data);
+  }
+
+  NAN_INLINE size_t length() const            { return length_; }
+  NAN_INLINE T* operator*()             { return data_;   }
+  NAN_INLINE const T* operator*() const { return data_;   }
+
+ private:
+  NAN_DISALLOW_ASSIGN_COPY_MOVE(TypedArrayContents)
+
+  //Disable heap allocation
+  void *operator new(size_t size);
+  void operator delete(void *, size_t);
+
+  size_t  length_;
+  T*      data_;
+};
+
+#endif  // NAN_TYPEDARRAY_CONTENTS_H_

--- a/deps/nan/nan_weak.h
+++ b/deps/nan/nan_weak.h
@@ -1,0 +1,422 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2015 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+#ifndef NAN_WEAK_H_
+#define NAN_WEAK_H_
+
+static const int kInternalFieldsInWeakCallback = 2;
+static const int kNoInternalFieldIndex = -1;
+
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
+  (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
+# define NAN_WEAK_PARAMETER_CALLBACK_DATA_TYPE_ \
+    v8::WeakCallbackInfo<WeakCallbackInfo<T> > const&
+# define NAN_WEAK_TWOFIELD_CALLBACK_DATA_TYPE_ \
+    NAN_WEAK_PARAMETER_CALLBACK_DATA_TYPE_
+# define NAN_WEAK_PARAMETER_CALLBACK_SIG_ NAN_WEAK_PARAMETER_CALLBACK_DATA_TYPE_
+# define NAN_WEAK_TWOFIELD_CALLBACK_SIG_ NAN_WEAK_TWOFIELD_CALLBACK_DATA_TYPE_
+#elif NODE_MODULE_VERSION > IOJS_1_1_MODULE_VERSION
+# define NAN_WEAK_PARAMETER_CALLBACK_DATA_TYPE_ \
+    v8::PhantomCallbackData<WeakCallbackInfo<T> > const&
+# define NAN_WEAK_TWOFIELD_CALLBACK_DATA_TYPE_ \
+    NAN_WEAK_PARAMETER_CALLBACK_DATA_TYPE_
+# define NAN_WEAK_PARAMETER_CALLBACK_SIG_ NAN_WEAK_PARAMETER_CALLBACK_DATA_TYPE_
+# define NAN_WEAK_TWOFIELD_CALLBACK_SIG_ NAN_WEAK_TWOFIELD_CALLBACK_DATA_TYPE_
+#elif NODE_MODULE_VERSION > NODE_0_12_MODULE_VERSION
+# define NAN_WEAK_PARAMETER_CALLBACK_DATA_TYPE_ \
+    v8::PhantomCallbackData<WeakCallbackInfo<T> > const&
+# define NAN_WEAK_TWOFIELD_CALLBACK_DATA_TYPE_ \
+    v8::InternalFieldsCallbackData<WeakCallbackInfo<T>, void> const&
+# define NAN_WEAK_PARAMETER_CALLBACK_SIG_ NAN_WEAK_PARAMETER_CALLBACK_DATA_TYPE_
+# define NAN_WEAK_TWOFIELD_CALLBACK_SIG_ NAN_WEAK_TWOFIELD_CALLBACK_DATA_TYPE_
+#elif NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION
+# define NAN_WEAK_CALLBACK_DATA_TYPE_ \
+    v8::WeakCallbackData<S, WeakCallbackInfo<T> > const&
+# define NAN_WEAK_CALLBACK_SIG_ NAN_WEAK_CALLBACK_DATA_TYPE_
+#else
+# define NAN_WEAK_CALLBACK_DATA_TYPE_ void *
+# define NAN_WEAK_CALLBACK_SIG_ \
+    v8::Persistent<v8::Value>, NAN_WEAK_CALLBACK_DATA_TYPE_
+#endif
+
+template<typename T>
+class WeakCallbackInfo {
+ public:
+  typedef void (*Callback)(const WeakCallbackInfo<T>& data);
+  WeakCallbackInfo(
+      Persistent<v8::Value> *persistent
+    , Callback callback
+    , void *parameter
+    , void *field1 = 0
+    , void *field2 = 0) :
+        callback_(callback), isolate_(0), parameter_(parameter) {
+    std::memcpy(&persistent_, persistent, sizeof (v8::Persistent<v8::Value>));
+    internal_fields_[0] = field1;
+    internal_fields_[1] = field2;
+  }
+  NAN_INLINE v8::Isolate *GetIsolate() const { return isolate_; }
+  NAN_INLINE T *GetParameter() const { return static_cast<T*>(parameter_); }
+  NAN_INLINE void *GetInternalField(int index) const {
+    assert((index == 0 || index == 1) && "internal field index out of bounds");
+    if (index == 0) {
+      return internal_fields_[0];
+    } else {
+      return internal_fields_[1];
+    }
+  }
+
+ private:
+  NAN_DISALLOW_ASSIGN_COPY_MOVE(WeakCallbackInfo)
+  Callback callback_;
+  v8::Isolate *isolate_;
+  void *parameter_;
+  void *internal_fields_[kInternalFieldsInWeakCallback];
+  v8::Persistent<v8::Value> persistent_;
+  template<typename S, typename M> friend class Persistent;
+  template<typename S> friend class PersistentBase;
+#if NODE_MODULE_VERSION <= NODE_0_12_MODULE_VERSION
+# if NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION
+  template<typename S>
+  static void invoke(NAN_WEAK_CALLBACK_SIG_ data);
+  template<typename S>
+  static WeakCallbackInfo *unwrap(NAN_WEAK_CALLBACK_DATA_TYPE_ data);
+# else
+  static void invoke(NAN_WEAK_CALLBACK_SIG_ data);
+  static WeakCallbackInfo *unwrap(NAN_WEAK_CALLBACK_DATA_TYPE_ data);
+# endif
+#else
+  static void invokeparameter(NAN_WEAK_PARAMETER_CALLBACK_SIG_ data);
+  static void invoketwofield(NAN_WEAK_TWOFIELD_CALLBACK_SIG_ data);
+  static WeakCallbackInfo *unwrapparameter(
+      NAN_WEAK_PARAMETER_CALLBACK_DATA_TYPE_ data);
+  static WeakCallbackInfo *unwraptwofield(
+      NAN_WEAK_TWOFIELD_CALLBACK_DATA_TYPE_ data);
+#endif
+};
+
+
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
+  (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
+
+template<typename T>
+void
+WeakCallbackInfo<T>::invokeparameter(NAN_WEAK_PARAMETER_CALLBACK_SIG_ data) {
+  WeakCallbackInfo<T> *cbinfo = unwrapparameter(data);
+  if (data.IsFirstPass()) {
+    cbinfo->persistent_.Reset();
+    data.SetSecondPassCallback(invokeparameter);
+  } else {
+    cbinfo->callback_(*cbinfo);
+    delete cbinfo;
+  }
+}
+
+template<typename T>
+void
+WeakCallbackInfo<T>::invoketwofield(NAN_WEAK_TWOFIELD_CALLBACK_SIG_ data) {
+  WeakCallbackInfo<T> *cbinfo = unwraptwofield(data);
+  if (data.IsFirstPass()) {
+    cbinfo->persistent_.Reset();
+    data.SetSecondPassCallback(invoketwofield);
+  } else {
+    cbinfo->callback_(*cbinfo);
+    delete cbinfo;
+  }
+}
+
+template<typename T>
+WeakCallbackInfo<T> *WeakCallbackInfo<T>::unwrapparameter(
+    NAN_WEAK_PARAMETER_CALLBACK_DATA_TYPE_ data) {
+  WeakCallbackInfo<T> *cbinfo =
+      static_cast<WeakCallbackInfo<T>*>(data.GetParameter());
+  cbinfo->isolate_ = data.GetIsolate();
+  return cbinfo;
+}
+
+template<typename T>
+WeakCallbackInfo<T> *WeakCallbackInfo<T>::unwraptwofield(
+    NAN_WEAK_TWOFIELD_CALLBACK_DATA_TYPE_ data) {
+  WeakCallbackInfo<T> *cbinfo =
+      static_cast<WeakCallbackInfo<T>*>(data.GetInternalField(0));
+  cbinfo->isolate_ = data.GetIsolate();
+  return cbinfo;
+}
+
+#undef NAN_WEAK_PARAMETER_CALLBACK_SIG_
+#undef NAN_WEAK_TWOFIELD_CALLBACK_SIG_
+#undef NAN_WEAK_PARAMETER_CALLBACK_DATA_TYPE_
+#undef NAN_WEAK_TWOFIELD_CALLBACK_DATA_TYPE_
+# elif NODE_MODULE_VERSION > NODE_0_12_MODULE_VERSION
+
+template<typename T>
+void
+WeakCallbackInfo<T>::invokeparameter(NAN_WEAK_PARAMETER_CALLBACK_SIG_ data) {
+  WeakCallbackInfo<T> *cbinfo = unwrapparameter(data);
+  cbinfo->persistent_.Reset();
+  cbinfo->callback_(*cbinfo);
+  delete cbinfo;
+}
+
+template<typename T>
+void
+WeakCallbackInfo<T>::invoketwofield(NAN_WEAK_TWOFIELD_CALLBACK_SIG_ data) {
+  WeakCallbackInfo<T> *cbinfo = unwraptwofield(data);
+  cbinfo->persistent_.Reset();
+  cbinfo->callback_(*cbinfo);
+  delete cbinfo;
+}
+
+template<typename T>
+WeakCallbackInfo<T> *WeakCallbackInfo<T>::unwrapparameter(
+    NAN_WEAK_PARAMETER_CALLBACK_DATA_TYPE_ data) {
+  WeakCallbackInfo<T> *cbinfo =
+       static_cast<WeakCallbackInfo<T>*>(data.GetParameter());
+  cbinfo->isolate_ = data.GetIsolate();
+  return cbinfo;
+}
+
+template<typename T>
+WeakCallbackInfo<T> *WeakCallbackInfo<T>::unwraptwofield(
+    NAN_WEAK_TWOFIELD_CALLBACK_DATA_TYPE_ data) {
+  WeakCallbackInfo<T> *cbinfo =
+       static_cast<WeakCallbackInfo<T>*>(data.GetInternalField1());
+  cbinfo->isolate_ = data.GetIsolate();
+  return cbinfo;
+}
+
+#undef NAN_WEAK_PARAMETER_CALLBACK_SIG_
+#undef NAN_WEAK_TWOFIELD_CALLBACK_SIG_
+#undef NAN_WEAK_PARAMETER_CALLBACK_DATA_TYPE_
+#undef NAN_WEAK_TWOFIELD_CALLBACK_DATA_TYPE_
+#elif NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION
+
+template<typename T>
+template<typename S>
+void WeakCallbackInfo<T>::invoke(NAN_WEAK_CALLBACK_SIG_ data) {
+  WeakCallbackInfo<T> *cbinfo = unwrap(data);
+  cbinfo->persistent_.Reset();
+  cbinfo->callback_(*cbinfo);
+  delete cbinfo;
+}
+
+template<typename T>
+template<typename S>
+WeakCallbackInfo<T> *WeakCallbackInfo<T>::unwrap(
+    NAN_WEAK_CALLBACK_DATA_TYPE_ data) {
+  void *parameter = data.GetParameter();
+  WeakCallbackInfo<T> *cbinfo =
+      static_cast<WeakCallbackInfo<T>*>(parameter);
+  cbinfo->isolate_ = data.GetIsolate();
+  return cbinfo;
+}
+
+#undef NAN_WEAK_CALLBACK_SIG_
+#undef NAN_WEAK_CALLBACK_DATA_TYPE_
+#else
+
+template<typename T>
+void WeakCallbackInfo<T>::invoke(NAN_WEAK_CALLBACK_SIG_ data) {
+  WeakCallbackInfo<T> *cbinfo = unwrap(data);
+  cbinfo->persistent_.Dispose();
+  cbinfo->persistent_.Clear();
+  cbinfo->callback_(*cbinfo);
+  delete cbinfo;
+}
+
+template<typename T>
+WeakCallbackInfo<T> *WeakCallbackInfo<T>::unwrap(
+    NAN_WEAK_CALLBACK_DATA_TYPE_ data) {
+  WeakCallbackInfo<T> *cbinfo =
+      static_cast<WeakCallbackInfo<T>*>(data);
+  cbinfo->isolate_ = v8::Isolate::GetCurrent();
+  return cbinfo;
+}
+
+#undef NAN_WEAK_CALLBACK_SIG_
+#undef NAN_WEAK_CALLBACK_DATA_TYPE_
+#endif
+
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
+  (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
+template<typename T, typename M>
+template<typename P>
+NAN_INLINE void Persistent<T, M>::SetWeak(
+    P *parameter
+  , typename WeakCallbackInfo<P>::Callback callback
+  , WeakCallbackType type) {
+  WeakCallbackInfo<P> *wcbd;
+  if (type == WeakCallbackType::kParameter) {
+    wcbd = new WeakCallbackInfo<P>(
+        reinterpret_cast<Persistent<v8::Value>*>(this)
+      , callback
+      , parameter);
+    v8::PersistentBase<T>::SetWeak(
+        wcbd
+      , WeakCallbackInfo<P>::invokeparameter
+      , type);
+  } else {
+    v8::Local<T>* self = reinterpret_cast<v8::Local<T>*>(this);
+    assert((*self)->IsObject());
+    int count = (*self)->InternalFieldCount();
+    void *internal_fields[kInternalFieldsInWeakCallback] = {0, 0};
+    for (int i = 0; i < count && i < kInternalFieldsInWeakCallback; i++) {
+      internal_fields[i] = (*self)->GetAlignedPointerFromInternalField(i);
+    }
+    wcbd = new WeakCallbackInfo<P>(
+        reinterpret_cast<Persistent<v8::Value>*>(this)
+      , callback
+      , 0
+      , internal_fields[0]
+      , internal_fields[1]);
+    (*self)->SetAlignedPointerInInternalField(0, wcbd);
+    v8::PersistentBase<T>::SetWeak(
+        static_cast<WeakCallbackInfo<P>*>(0)
+      , WeakCallbackInfo<P>::invoketwofield
+      , type);
+  }
+}
+#elif NODE_MODULE_VERSION > IOJS_1_1_MODULE_VERSION
+template<typename T, typename M>
+template<typename P>
+NAN_INLINE void Persistent<T, M>::SetWeak(
+    P *parameter
+  , typename WeakCallbackInfo<P>::Callback callback
+  , WeakCallbackType type) {
+  WeakCallbackInfo<P> *wcbd;
+  if (type == WeakCallbackType::kParameter) {
+    wcbd = new WeakCallbackInfo<P>(
+        reinterpret_cast<Persistent<v8::Value>*>(this)
+      , callback
+      , parameter);
+    v8::PersistentBase<T>::SetPhantom(
+        wcbd
+      , WeakCallbackInfo<P>::invokeparameter);
+  } else {
+    v8::Local<T>* self = reinterpret_cast<v8::Local<T>*>(this);
+    assert((*self)->IsObject());
+    int count = (*self)->InternalFieldCount();
+    void *internal_fields[kInternalFieldsInWeakCallback] = {0, 0};
+    for (int i = 0; i < count && i < kInternalFieldsInWeakCallback; i++) {
+      internal_fields[i] = (*self)->GetAlignedPointerFromInternalField(i);
+    }
+    wcbd = new WeakCallbackInfo<P>(
+        reinterpret_cast<Persistent<v8::Value>*>(this)
+      , callback
+      , 0
+      , internal_fields[0]
+      , internal_fields[1]);
+    (*self)->SetAlignedPointerInInternalField(0, wcbd);
+    v8::PersistentBase<T>::SetPhantom(
+        static_cast<WeakCallbackInfo<P>*>(0)
+      , WeakCallbackInfo<P>::invoketwofield
+      , 0
+      , count > 1 ? 1 : kNoInternalFieldIndex);
+  }
+}
+#elif NODE_MODULE_VERSION > NODE_0_12_MODULE_VERSION
+template<typename T, typename M>
+template<typename P>
+NAN_INLINE void Persistent<T, M>::SetWeak(
+    P *parameter
+  , typename WeakCallbackInfo<P>::Callback callback
+  , WeakCallbackType type) {
+  WeakCallbackInfo<P> *wcbd;
+  if (type == WeakCallbackType::kParameter) {
+    wcbd = new WeakCallbackInfo<P>(
+        reinterpret_cast<Persistent<v8::Value>*>(this)
+      , callback
+      , parameter);
+    v8::PersistentBase<T>::SetPhantom(
+        wcbd
+      , WeakCallbackInfo<P>::invokeparameter);
+  } else {
+    v8::Local<T>* self = reinterpret_cast<v8::Local<T>*>(this);
+    assert((*self)->IsObject());
+    int count = (*self)->InternalFieldCount();
+    void *internal_fields[kInternalFieldsInWeakCallback] = {0, 0};
+    for (int i = 0; i < count && i < kInternalFieldsInWeakCallback; i++) {
+      internal_fields[i] = (*self)->GetAlignedPointerFromInternalField(i);
+    }
+    wcbd = new WeakCallbackInfo<P>(
+        reinterpret_cast<Persistent<v8::Value>*>(this)
+      , callback
+      , 0
+      , internal_fields[0]
+      , internal_fields[1]);
+    (*self)->SetAlignedPointerInInternalField(0, wcbd);
+    v8::PersistentBase<T>::SetPhantom(
+        WeakCallbackInfo<P>::invoketwofield
+      , 0
+      , count > 1 ? 1 : kNoInternalFieldIndex);
+  }
+}
+#elif NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION
+template<typename T, typename M>
+template<typename P>
+NAN_INLINE void Persistent<T, M>::SetWeak(
+    P *parameter
+  , typename WeakCallbackInfo<P>::Callback callback
+  , WeakCallbackType type) {
+  WeakCallbackInfo<P> *wcbd;
+  if (type == WeakCallbackType::kParameter) {
+    wcbd = new WeakCallbackInfo<P>(
+        reinterpret_cast<Persistent<v8::Value>*>(this)
+      , callback
+      , parameter);
+    v8::PersistentBase<T>::SetWeak(wcbd, WeakCallbackInfo<P>::invoke);
+  } else {
+    v8::Local<T>* self = reinterpret_cast<v8::Local<T>*>(this);
+    assert((*self)->IsObject());
+    int count = (*self)->InternalFieldCount();
+    void *internal_fields[kInternalFieldsInWeakCallback] = {0, 0};
+    for (int i = 0; i < count && i < kInternalFieldsInWeakCallback; i++) {
+      internal_fields[i] = (*self)->GetAlignedPointerFromInternalField(i);
+    }
+    wcbd = new WeakCallbackInfo<P>(
+        reinterpret_cast<Persistent<v8::Value>*>(this)
+      , callback
+      , 0
+      , internal_fields[0]
+      , internal_fields[1]);
+    v8::PersistentBase<T>::SetWeak(wcbd, WeakCallbackInfo<P>::invoke);
+  }
+}
+#else
+template<typename T>
+template<typename P>
+NAN_INLINE void PersistentBase<T>::SetWeak(
+    P *parameter
+  , typename WeakCallbackInfo<P>::Callback callback
+  , WeakCallbackType type) {
+  WeakCallbackInfo<P> *wcbd;
+  if (type == WeakCallbackType::kParameter) {
+    wcbd = new WeakCallbackInfo<P>(
+        reinterpret_cast<Persistent<v8::Value>*>(this)
+      , callback
+      , parameter);
+    persistent.MakeWeak(wcbd, WeakCallbackInfo<P>::invoke);
+  } else {
+    v8::Local<T>* self = reinterpret_cast<v8::Local<T>*>(this);
+    assert((*self)->IsObject());
+    int count = (*self)->InternalFieldCount();
+    void *internal_fields[kInternalFieldsInWeakCallback] = {0, 0};
+    for (int i = 0; i < count && i < kInternalFieldsInWeakCallback; i++) {
+      internal_fields[i] = (*self)->GetPointerFromInternalField(i);
+    }
+    wcbd = new WeakCallbackInfo<P>(
+        reinterpret_cast<Persistent<v8::Value>*>(this)
+      , callback
+      , 0
+      , internal_fields[0]
+      , internal_fields[1]);
+    persistent.MakeWeak(wcbd, WeakCallbackInfo<P>::invoke);
+  }
+}
+#endif
+
+#endif  // NAN_WEAK_H_

--- a/deps/nan/package.json
+++ b/deps/nan/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "nan",
+  "version": "2.1.0",
+  "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 4 compatibility",
+  "main": "include_dirs.js",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/nodejs/nan.git"
+  },
+  "scripts": {
+    "test": "tap --gc test/js/*-test.js",
+    "rebuild-tests": "node-gyp rebuild --msvs_version=2013 --directory test",
+    "docs": "doc/.build.sh"
+  },
+  "contributors": [
+    "Rod Vagg <r@va.gg> (https://github.com/rvagg)",
+    "Benjamin Byholm <bbyholm@abo.fi> (https://github.com/kkoopa/)",
+    "Trevor Norris <trev.norris@gmail.com> (https://github.com/trevnorris)",
+    "Nathan Rajlich <nathan@tootallnate.net> (https://github.com/TooTallNate)",
+    "Brett Lawson <brett19@gmail.com> (https://github.com/brett19)",
+    "Ben Noordhuis <info@bnoordhuis.nl> (https://github.com/bnoordhuis)",
+    "David Siegel <david@artcom.de> (https://github.com/agnat)"
+  ],
+  "devDependencies": {
+    "bindings": "~1.2.1",
+    "commander": "^2.8.1",
+    "glob": "^5.0.14",
+    "node-gyp": "~3.0.1",
+    "tap": "~0.7.1",
+    "xtend": "~4.0.0"
+  },
+  "license": "MIT"
+}

--- a/deps/nan/tools/1to2.js
+++ b/deps/nan/tools/1to2.js
@@ -1,0 +1,412 @@
+#!/usr/bin/env node
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2015 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+var commander = require('commander'),
+    fs = require('fs'),
+    glob = require('glob'),
+    groups = [],
+    total = 0,
+    warning1 = '/* ERROR: Rewrite using Buffer */\n',
+    warning2 = '\\/\\* ERROR\\: Rewrite using Buffer \\*\\/\\n',
+    length,
+    i;
+
+fs.readFile('package.json', 'utf8', function (err, data) {
+  if (err) {
+    throw err;
+  }
+
+  commander
+      .version(JSON.parse(data).version)
+      .usage('[options] <file ...>')
+      .parse(process.argv);
+
+  if (!process.argv.slice(2).length) {
+    commander.outputHelp();
+  }
+});
+
+/* construct strings representing regular expressions
+   each expression contains a unique group allowing for identification of the match
+   the index of this key group, relative to the regular expression in question,
+    is indicated by the first array member */
+
+/* simple substistutions, key group is the entire match, 0 */
+groups.push([0, [
+  '_NAN_',
+  'NODE_SET_METHOD',
+  'NODE_SET_PROTOTYPE_METHOD',
+  'NanAsciiString',
+  'NanEscapeScope',
+  'NanReturnValue',
+  'NanUcs2String'].join('|')]);
+
+/* substitutions of parameterless macros, key group is 1 */
+groups.push([1, ['(', [
+  'NanEscapableScope',
+  'NanReturnNull',
+  'NanReturnUndefined',
+  'NanScope'].join('|'), ')\\(\\)'].join('')]);
+
+/* replace TryCatch with NanTryCatch once, gobbling possible namespace, key group 2 */
+groups.push([2, '(?:(?:v8\\:\\:)?|(Nan)?)(TryCatch)']);
+
+/* NanNew("string") will likely not fail a ToLocalChecked(), key group 1 */ 
+groups.push([1, ['(NanNew)', '(\\("[^\\"]*"[^\\)]*\\))(?!\\.ToLocalChecked\\(\\))'].join('')]);
+
+/* Removed v8 APIs, warn that the code needs rewriting using node::Buffer, key group 2 */
+groups.push([2, ['(', warning2, ')?', '^.*?(', [
+      'GetIndexedPropertiesExternalArrayDataLength',
+      'GetIndexedPropertiesExternalArrayData',
+      'GetIndexedPropertiesExternalArrayDataType',
+      'GetIndexedPropertiesPixelData',
+      'GetIndexedPropertiesPixelDataLength',
+      'HasIndexedPropertiesInExternalArrayData',
+      'HasIndexedPropertiesInPixelData',
+      'SetIndexedPropertiesToExternalArrayData',
+      'SetIndexedPropertiesToPixelData'].join('|'), ')'].join('')]);
+
+/* No need for NanScope in V8-exposed methods, key group 2 */
+groups.push([2, ['((', [
+      'NAN_METHOD',
+      'NAN_GETTER',
+      'NAN_SETTER',
+      'NAN_PROPERTY_GETTER',
+      'NAN_PROPERTY_SETTER',
+      'NAN_PROPERTY_ENUMERATOR',
+      'NAN_PROPERTY_DELETER',
+      'NAN_PROPERTY_QUERY',
+      'NAN_INDEX_GETTER',
+      'NAN_INDEX_SETTER',
+      'NAN_INDEX_ENUMERATOR',
+      'NAN_INDEX_DELETER',
+      'NAN_INDEX_QUERY'].join('|'), ')\\([^\\)]*\\)\\s*\\{)\\s*NanScope\\(\\)\\s*;'].join('')]);
+
+/* v8::Value::ToXXXXXXX returns v8::MaybeLocal<T>, key group 3 */
+groups.push([3, ['([\\s\\(\\)])([^\\s\\(\\)]+)->(', [
+      'Boolean',
+      'Number',
+      'String',
+      'Object',
+      'Integer',
+      'Uint32',
+      'Int32'].join('|'), ')\\('].join('')]);
+
+/* v8::Value::XXXXXXXValue returns v8::Maybe<T>, key group 3 */
+groups.push([3, ['([\\s\\(\\)])([^\\s\\(\\)]+)->((?:', [
+      'Boolean',
+      'Number',
+      'Integer',
+      'Uint32',
+      'Int32'].join('|'), ')Value)\\('].join('')]);
+
+/* NAN_WEAK_CALLBACK macro was removed, write out callback definition, key group 1 */
+groups.push([1, '(NAN_WEAK_CALLBACK)\\(([^\\s\\)]+)\\)']);
+
+/* node::ObjectWrap and v8::Persistent have been replaced with Nan implementations, key group 1 */
+groups.push([1, ['(', [
+  'NanDisposePersistent',
+  'NanObjectWrapHandle'].join('|'), ')\\s*\\(\\s*([^\\s\\)]+)'].join('')]);
+
+/* Since NanPersistent there is no need for NanMakeWeakPersistent, key group 1 */
+groups.push([1, '(NanMakeWeakPersistent)\\s*\\(\\s*([^\\s,]+)\\s*,\\s*']);
+
+/* Many methods of v8::Object and others now return v8::MaybeLocal<T>, key group 3 */
+groups.push([3, ['([\\s])([^\\s]+)->(', [
+  'GetEndColumn',
+  'GetFunction',
+  'GetLineNumber',
+  'NewInstance',
+  'GetPropertyNames',
+  'GetOwnPropertyNames',
+  'GetSourceLine',
+  'GetStartColumn',
+  'ObjectProtoToString',
+  'ToArrayIndex',
+  'ToDetailString',
+  'CallAsConstructor',
+  'CallAsFunction',
+  'CloneElementAt',
+  'Delete',
+  'ForceSet',
+  'Get',
+  'GetPropertyAttributes',
+  'GetRealNamedProperty',
+  'GetRealNamedPropertyInPrototypeChain',
+  'Has',
+  'HasOwnProperty',
+  'HasRealIndexedProperty',
+  'HasRealNamedCallbackProperty',
+  'HasRealNamedProperty',
+  'Set',
+  'SetAccessor',
+  'SetIndexedPropertyHandler',
+  'SetNamedPropertyHandler',
+  'SetPrototype'].join('|'), ')\\('].join('')]);
+
+/* You should get an error if any of these fail anyways,
+   or handle the error better, it is indicated either way, key group 2 */
+groups.push([2, ['NanNew(<(?:v8\\:\\:)?(', ['Date', 'String', 'RegExp'].join('|'), ')>)(\\([^\\)]*\\))(?!\\.ToLocalChecked\\(\\))'].join('')]);
+
+/* v8::Value::Equals now returns a v8::Maybe, key group 3 */
+groups.push([3, '([\\s\\(\\)])([^\\s\\(\\)]+)->(Equals)\\(([^\\s\\)]+)']);
+
+/* NanPersistent makes this unnecessary, key group 1 */
+groups.push([1, '(NanAssignPersistent)(?:<v8\\:\\:[^>]+>)?\\(([^,]+),\\s*']);
+
+/* args has been renamed to info, key group 2 */
+groups.push([2, '(\\W)(args)(\\W)'])
+
+/* node::ObjectWrap was replaced with NanObjectWrap, key group 2 */
+groups.push([2, '(\\W)(?:node\\:\\:)?(ObjectWrap)(\\W)']);
+
+/* v8::Persistent was replaced with NanPersistent, key group 2 */
+groups.push([2, '(\\W)(?:v8\\:\\:)?(Persistent)(\\W)']);
+
+/* counts the number of capturing groups in a well-formed regular expression,
+   ignoring non-capturing groups and escaped parentheses */
+function groupcount(s) {
+  var positive = s.match(/\((?!\?)/g),
+      negative = s.match(/\\\(/g);
+  return (positive ? positive.length : 0) - (negative ? negative.length : 0);
+}
+
+/* compute the absolute position of each key group in the joined master RegExp */
+for (i = 1, length = groups.length; i < length; i++) {
+	total += groupcount(groups[i - 1][1]);
+	groups[i][0] += total;
+}
+
+/* create the master RegExp, whis is the union of all the groups' expressions */
+master = new RegExp(groups.map(function (a) { return a[1]; }).join('|'), 'gm');
+
+/* replacement function for String.replace, receives 21 arguments */
+function replace() {
+	/* simple expressions */
+      switch (arguments[groups[0][0]]) {
+        case '_NAN_':
+          return 'NAN_';
+        case 'NODE_SET_METHOD':
+          return 'NanSetMethod';
+        case 'NODE_SET_PROTOTYPE_METHOD':
+          return 'NanSetPrototypeMethod';
+        case 'NanAsciiString':
+          return 'NanUtf8String';
+        case 'NanEscapeScope':
+          return 'scope.Escape';
+        case 'NanReturnNull':
+          return 'info.GetReturnValue().SetNull';
+        case 'NanReturnValue':
+          return 'info.GetReturnValue().Set';
+        case 'NanUcs2String':
+          return 'v8::String::Value';
+        default:
+      }
+
+      /* macros without arguments */
+      switch (arguments[groups[1][0]]) {
+        case 'NanEscapableScope':
+          return 'NanEscapableScope scope'
+        case 'NanReturnUndefined':
+          return 'return';
+        case 'NanScope':
+          return 'NanScope scope';
+        default:
+      }
+
+      /* TryCatch, emulate negative backref */
+      if (arguments[groups[2][0]] === 'TryCatch') {
+        return arguments[groups[2][0] - 1] ? arguments[0] : 'NanTryCatch';
+      }
+
+      /* NanNew("foo") --> NanNew("foo").ToLocalChecked() */
+      if (arguments[groups[3][0]] === 'NanNew') {
+        return [arguments[0], '.ToLocalChecked()'].join('');
+      }
+
+      /* insert warning for removed functions as comment on new line above */
+      switch (arguments[groups[4][0]]) {
+        case 'GetIndexedPropertiesExternalArrayData':
+        case 'GetIndexedPropertiesExternalArrayDataLength':
+        case 'GetIndexedPropertiesExternalArrayDataType':
+        case 'GetIndexedPropertiesPixelData':
+        case 'GetIndexedPropertiesPixelDataLength':
+        case 'HasIndexedPropertiesInExternalArrayData':
+        case 'HasIndexedPropertiesInPixelData':
+        case 'SetIndexedPropertiesToExternalArrayData':
+        case 'SetIndexedPropertiesToPixelData':
+          return arguments[groups[4][0] - 1] ? arguments[0] : [warning1, arguments[0]].join('');
+        default:
+      }
+
+     /* remove unnecessary NanScope() */
+      switch (arguments[groups[5][0]]) {
+        case 'NAN_GETTER':
+        case 'NAN_METHOD':
+        case 'NAN_SETTER':
+        case 'NAN_INDEX_DELETER':
+        case 'NAN_INDEX_ENUMERATOR':
+        case 'NAN_INDEX_GETTER':
+        case 'NAN_INDEX_QUERY':
+        case 'NAN_INDEX_SETTER':
+        case 'NAN_PROPERTY_DELETER':
+        case 'NAN_PROPERTY_ENUMERATOR':
+        case 'NAN_PROPERTY_GETTER':
+        case 'NAN_PROPERTY_QUERY':
+        case 'NAN_PROPERTY_SETTER':
+          return arguments[groups[5][0] - 1];
+        default:
+      }
+
+      /* Value converstion */
+      switch (arguments[groups[6][0]]) {
+        case 'Boolean':
+        case 'Int32':
+        case 'Integer':
+        case 'Number':
+        case 'Object':
+        case 'String':
+        case 'Uint32':
+          return [arguments[groups[6][0] - 2], 'NanTo<v8::', arguments[groups[6][0]], '>(',  arguments[groups[6][0] - 1]].join('');
+        default:
+      }
+
+      /* other value conversion */
+      switch (arguments[groups[7][0]]) {
+        case 'BooleanValue':
+          return [arguments[groups[7][0] - 2], 'NanTo<bool>(', arguments[groups[7][0] - 1]].join('');
+        case 'Int32Value':
+          return [arguments[groups[7][0] - 2], 'NanTo<int32_t>(', arguments[groups[7][0] - 1]].join('');
+        case 'IntegerValue':
+          return [arguments[groups[7][0] - 2], 'NanTo<int64_t>(', arguments[groups[7][0] - 1]].join('');
+        case 'Uint32Value':
+          return [arguments[groups[7][0] - 2], 'NanTo<uint32_t>(', arguments[groups[7][0] - 1]].join('');
+        default:
+      }
+
+      /* NAN_WEAK_CALLBACK */
+      if (arguments[groups[8][0]] === 'NAN_WEAK_CALLBACK') {
+        return ['template<typename T>\nvoid ',
+          arguments[groups[8][0] + 1], '(const NanWeakCallbackInfo<T> &data)'].join('');
+      }
+
+      /* use methods on NAN classes instead */
+      switch (arguments[groups[9][0]]) {
+        case 'NanDisposePersistent':
+          return [arguments[groups[9][0] + 1], '.Reset('].join('');
+        case 'NanObjectWrapHandle':
+          return [arguments[groups[9][0] + 1], '->handle('].join('');
+        default:
+      }
+
+      /* use method on NanPersistent instead */
+      if (arguments[groups[10][0]] === 'NanMakeWeakPersistent') {
+        return arguments[groups[10][0] + 1] + '.SetWeak(';
+      }
+
+      /* These return Maybes, the upper ones take no arguments */
+      switch (arguments[groups[11][0]]) {
+        case 'GetEndColumn':
+        case 'GetFunction':
+        case 'GetLineNumber':
+        case 'GetOwnPropertyNames':
+        case 'GetPropertyNames':
+        case 'GetSourceLine':
+        case 'GetStartColumn':
+        case 'NewInstance':
+        case 'ObjectProtoToString':
+        case 'ToArrayIndex':
+        case 'ToDetailString':
+          return [arguments[groups[11][0] - 2], 'Nan', arguments[groups[11][0]], '(', arguments[groups[11][0] - 1]].join('');
+        case 'CallAsConstructor':
+        case 'CallAsFunction':
+        case 'CloneElementAt':
+        case 'Delete':
+        case 'ForceSet':
+        case 'Get':
+        case 'GetPropertyAttributes':
+        case 'GetRealNamedProperty':
+        case 'GetRealNamedPropertyInPrototypeChain':
+        case 'Has':
+        case 'HasOwnProperty':
+        case 'HasRealIndexedProperty':
+        case 'HasRealNamedCallbackProperty':
+        case 'HasRealNamedProperty':
+        case 'Set':
+        case 'SetAccessor':
+        case 'SetIndexedPropertyHandler':
+        case 'SetNamedPropertyHandler':
+        case 'SetPrototype':
+          return [arguments[groups[11][0] - 2], 'Nan', arguments[groups[11][0]], '(', arguments[groups[11][0] - 1], ', '].join('');
+        default:
+      }
+
+      /* Automatic ToLocalChecked(), take it or leave it */
+      switch (arguments[groups[12][0]]) {
+        case 'Date':
+        case 'String':
+        case 'RegExp':
+          return ['NanNew', arguments[groups[12][0] - 1], arguments[groups[12][0] + 1], '.ToLocalChecked()'].join('');
+        default:
+      }
+
+      /* NanEquals is now required for uniformity */
+      if (arguments[groups[13][0]] === 'Equals') {
+        return [arguments[groups[13][0] - 1], 'NanEquals(', arguments[groups[13][0] - 1], ', ', arguments[groups[13][0] + 1]].join('');
+      }
+
+      /* use method on replacement class instead */
+      if (arguments[groups[14][0]] === 'NanAssignPersistent') {
+        return [arguments[groups[14][0] + 1], '.Reset('].join('');
+      }
+
+      /* args --> info */
+      if (arguments[groups[15][0]] === 'args') {
+        return [arguments[groups[15][0] - 1], 'info', arguments[groups[15][0] + 1]].join('');
+      }
+
+      /* ObjectWrap --> NanObjectWrap */
+      if (arguments[groups[16][0]] === 'ObjectWrap') {
+        return [arguments[groups[16][0] - 1], 'NanObjectWrap', arguments[groups[16][0] + 1]].join('');
+      }
+
+      /* Persistent --> NanPersistent */
+      if (arguments[groups[17][0]] === 'Persistent') {
+        return [arguments[groups[17][0] - 1], 'NanPersistent', arguments[groups[17][0] + 1]].join('');
+      }
+
+      /* This should not happen. A switch is probably missing a case if it does. */
+      throw 'Unhandled match: ' + arguments[0];
+}
+
+/* reads a file, runs replacement and writes it back */
+function processFile(file) {
+  fs.readFile(file, {encoding: 'utf8'}, function (err, data) {
+    if (err) {
+      throw err;
+    }
+
+    /* run replacement twice, might need more runs */
+    fs.writeFile(file, data.replace(master, replace).replace(master, replace), function (err) {
+      if (err) {
+        throw err;
+      }
+    });
+  });
+}
+
+/* process file names from command line and process the identified files */
+for (i = 2, length = process.argv.length; i < length; i++) {
+  glob(process.argv[i], function (err, matches) {
+    if (err) {
+      throw err;
+    }
+    matches.forEach(processFile);
+  });
+}

--- a/deps/nan/tools/README.md
+++ b/deps/nan/tools/README.md
@@ -1,0 +1,14 @@
+1to2 naively converts source code files from NAN 1 to NAN 2. There will be erroneous conversions,
+false positives and missed opportunities. The input files are rewritten in place. Make sure that
+you have backups. You will have to manually review the changes afterwards and do some touchups.
+
+```sh
+$ tools/1to2.js
+
+  Usage: 1to2 [options] <file ...>
+
+  Options:
+
+    -h, --help     output usage information
+    -V, --version  output the version number
+```

--- a/deps/nan/tools/package.json
+++ b/deps/nan/tools/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "1to2",
+  "version": "1.0.0",
+  "description": "NAN 1 -> 2 Migration Script",
+  "main": "1to2.js",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/nodejs/nan.git"
+  },
+  "contributors": [
+    "Benjamin Byholm <bbyholm@abo.fi> (https://github.com/kkoopa/)",
+    "Mathias Küsel (https://github.com/mathiask88/)"
+  ],
+  "dependencies": {
+    "glob": "~5.0.10",
+    "commander": "~2.8.1"
+  },
+  "license": "MIT"
+}

--- a/node.gyp
+++ b/node.gyp
@@ -92,6 +92,7 @@
       'deps/v8/tools/tickprocessor.js',
       'deps/v8/tools/SourceMap.js',
       'deps/v8/tools/tickprocessor-driver.js',
+      'sample_heap/sample_heap.js',
     ],
   },
 
@@ -112,7 +113,8 @@
         'tools/msvs/genfiles',
         'deps/uv/src/ares',
         '<(SHARED_INTERMEDIATE_DIR)', # for node_natives.h
-        'deps/v8' # include/v8_platform.h
+        'deps/v8', # include/v8_platform.h
+        'deps/nan'
       ],
 
       'sources': [
@@ -151,6 +153,7 @@
         'src/process_wrap.cc',
         'src/udp_wrap.cc',
         'src/uv.cc',
+        'sample_heap/sample_heap.cc',
         # headers to make for a more pleasant IDE experience
         'src/async-wrap.h',
         'src/async-wrap-inl.h',
@@ -192,6 +195,26 @@
         'deps/http_parser/http_parser.h',
         'deps/v8/include/v8.h',
         'deps/v8/include/v8-debug.h',
+
+        # nan 2.0.5
+        'deps/nan/nan.h',
+        'deps/nan/nan_callbacks.h',
+        'deps/nan/nan_callbacks_12_inl.h',
+        'deps/nan/nan_callbacks_pre_12_inl.h',
+        'deps/nan/nan_converters.h',
+        'deps/nan/nan_converters_43_inl.h',
+        'deps/nan/nan_converters_pre_43_inl.h',
+        'deps/nan/nan_implementation_12_inl.h',
+        'deps/nan/nan_implementation_pre_12_inl.h',
+        'deps/nan/nan_maybe_43_inl.h',
+        'deps/nan/nan_maybe_pre_43_inl.h',
+        'deps/nan/nan_new.h',
+        'deps/nan/nan_object_wrap.h',
+        'deps/nan/nan_persistent_12_inl.h',
+        'deps/nan/nan_persistent_pre_12_inl.h',
+        'deps/nan/nan_string_bytes.h',
+        'deps/nan/nan_weak.h',
+
         '<(SHARED_INTERMEDIATE_DIR)/node_natives.h',
         # javascript files to make for an even more pleasant IDE experience
         '<@(library_files)',

--- a/sample_heap/example.js
+++ b/sample_heap/example.js
@@ -1,0 +1,48 @@
+'use strict'
+
+const sp = require('sample_heap')
+
+function inspect (obj, depth) {
+  if (typeof console.error === 'function') {
+    console.error(require('util').inspect(obj, false, depth || 5, true))
+  }
+}
+
+function mytest () {
+  const arr = []
+  const OUTER_ITER = 1024
+  const INNER_ITER = 1024 * 10
+
+  for (let j = 0; j < OUTER_ITER; j++) {
+    let innerArr = []
+    for (let i = 0; i < INNER_ITER; i++) {
+      innerArr.push({ i: i })
+    }
+    arr.push(innerArr)
+  }
+}
+
+function bar (size) { return new Array(size) }
+
+function v8test () {
+  var A = []
+  var foo = function () {
+    for (var i = 0; i < 1024; ++i) {
+      A[i] = bar(1024)
+    }
+  }
+  foo()
+}
+
+function onNode (info) {
+  inspect(info)
+}
+
+sp.startSampling(32, 10)
+
+mytest()
+v8test()
+
+sp.visitAllocationProfile(onNode)
+sp.stopSampling()
+

--- a/sample_heap/sample_heap.cc
+++ b/sample_heap/sample_heap.cc
@@ -1,0 +1,93 @@
+#include <node.h>
+#include <nan.h>
+#include <v8-profiler.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+using v8::AllocationProfile;
+using v8::Function;
+using v8::FunctionTemplate;
+using v8::Handle;
+using v8::HeapProfiler;
+using v8::Local;
+using v8::Integer;
+using v8::Object;
+using v8::String;
+using v8::Value;
+
+static void WalkAllocationStack(
+    Local<Value> recv,
+    Local<Function> alloc_fn,
+    Local<Function> function_fn,
+    AllocationProfile::Node *node,
+    uint32_t depth = 0) {
+
+  // report current callsite information
+  Local<Value> argv[] = {
+    Nan::New(depth),
+    node->name,
+    node->script_name,
+    Nan::New(node->script_id),
+    Nan::New(node->start_position),
+    Nan::New(node->line_number),
+    Nan::New(node->column_number),
+  };
+  function_fn->Call(recv, 7, argv);
+
+  // report all allocations for this callsite
+  auto allocations = node->allocations;
+  for (v8::AllocationProfile::Allocation allocation : allocations) {
+    Local<Value> alloc_argv[] = {
+      Nan::New((uint32_t)allocation.size),
+      Nan::New(allocation.count)
+    };
+    alloc_fn->Call(recv, 2, alloc_argv);
+  }
+
+  // walk all children of the current callsite and report the above for all of them
+  auto children = node->children;
+  for (v8::AllocationProfile::Node* child : children) {
+    WalkAllocationStack(
+        recv,
+        alloc_fn,
+        function_fn,
+        child,
+        depth + 1);
+  }
+}
+
+NAN_METHOD(StartSampling) {
+  Local<Integer> interval = info[0].As<Integer>();
+  Local<Integer> stack_depth = info[1].As<Integer>();
+  HeapProfiler* hp = info.GetIsolate()->GetHeapProfiler();
+  hp->StartSamplingHeapProfiler(interval->Value(), stack_depth->Value());
+}
+
+NAN_METHOD(StopSampling) {
+  HeapProfiler* hp = info.GetIsolate()->GetHeapProfiler();
+  hp->StopSamplingHeapProfiler();
+}
+
+NAN_METHOD(AllocationProfile) {
+  Local<Function> alloc_fn = info[0].As<Function>();
+  Local<Function> function_fn = info[1].As<Function>();
+
+  HeapProfiler* hp = info.GetIsolate()->GetHeapProfiler();
+  v8::AllocationProfile *profile = hp->GetAllocationProfile();
+  WalkAllocationStack(
+      Null(info.GetIsolate()),
+      alloc_fn,
+      function_fn,
+      profile->GetRootNode());
+}
+
+static void Init(Handle<Object> exports) {
+  exports->Set(Nan::New<String>("startSampling").ToLocalChecked(),
+    Nan::New<FunctionTemplate>(StartSampling)->GetFunction());
+  exports->Set(Nan::New<String>("stopSampling").ToLocalChecked(),
+    Nan::New<FunctionTemplate>(StopSampling)->GetFunction());
+  exports->Set(Nan::New<String>("allocationProfile").ToLocalChecked(),
+    Nan::New<FunctionTemplate>(AllocationProfile)->GetFunction());
+}
+
+NODE_MODULE(_heap_sampler, Init)

--- a/sample_heap/sample_heap.js
+++ b/sample_heap/sample_heap.js
@@ -1,0 +1,51 @@
+'use strict'
+
+const binding = process._linkedBinding('_heap_sampler')
+
+exports.startSampling = function startSampling (interval = 32, stack_depth = 6) {
+  // todo: ensure these are integers
+  binding.startSampling(interval, stack_depth)
+}
+
+exports.stopSampling = function stopSampling () {
+  binding.stopSampling()
+}
+
+exports.visitAllocationProfile = function visitAllocationProfile (cb) {
+  const samples = []
+  let sample = null
+  let currentCallSite
+  function onCall (depth, name,
+                   script_name,
+                   script_id,
+                   start_position,
+                   line_number,
+                   column_number) {
+    // back at the top of the stack means we're dealing with a new sample
+    if (depth === 1 && sample) {
+      // push the previously collected sample and start over
+      samples.push(sample)
+      sample = { callsites: [] }
+    }
+    currentCallSite = {
+      depth: depth,
+      name: name,
+      script: script_name,
+      script_id: script_id,
+      start_position: start_position,
+      line_number: line_number,
+      column_number: column_number,
+      allocations: []
+    }
+
+    if (!sample) sample = { callsites: [] }
+    sample.callsites.push(currentCallSite)
+  }
+  function onAlloc (size, count) {
+    const allocation = { size: size, count: count }
+    currentCallSite.allocations.push(allocation)
+  }
+  binding.allocationProfile(onAlloc, onCall)
+
+  cb(samples)
+}


### PR DESCRIPTION
@brycebaril @trevnorris with this spike I'm able to produce the below.
The [second commit](https://github.com/thlorenz/node/pull/1/commits/0182741a558874d5645b8357cd7c7ed7a6c7cb58) is the only one relevant (adding NaN in the first one).

As you can see no indication is given as to what object was created, just the size and the count.
That seems to be intended as the `Allocation` struct has no more info than that as you can see [here](https://github.com/thlorenz/node/blob/fork/profiling/heap-sample/deps/v8/include/v8-profiler.h#L434).
I hope @ofrobots can shine some light on that and/or let us know what we are missing here.

The callsites represent the stacktrace down to the highest depth at which the objects are created.

``` js
[ { callsites: 
     [ { depth: 0,
         name: '(root)',
         script: '',
         script_id: 0,
         start_position: 0,
         line_number: 0,
         column_number: 0,
         allocations: [] } ] },
  { callsites: 
     [ { depth: 1,
         name: 'Module.runMain',
         script: 'module.js',
         script_id: 42,
         start_position: 12726,
         line_number: 449,
         column_number: 26,
         allocations: [] },
       { depth: 2,
         name: 'Module._load',
         script: 'module.js',
         script_id: 42,
         start_position: 8228,
         line_number: 285,
         column_number: 24,
         allocations: [] },
       { depth: 3,
         name: 'Module.load',
         script: 'module.js',
         script_id: 42,
         start_position: 9692,
         line_number: 348,
         column_number: 33,
         allocations: [] },
       { depth: 4,
         name: 'Module._extensions..js',
         script: 'module.js',
         script_id: 42,
         start_position: 12077,
         line_number: 424,
         column_number: 37,
         allocations: [] },
       { depth: 5,
         name: 'Module._compile',
         script: 'module.js',
         script_id: 42,
         start_position: 10697,
         line_number: 380,
         column_number: 37,
         allocations: [] },
       { depth: 6,
         name: '',
         script: '/Volumes/d/dev/ns/nsolid/nsolid-node/sample_heap/example.js',
         script_id: 53,
         start_position: 10,
         line_number: 1,
         column_number: 11,
         allocations: 
          [ { size: 24, count: 8 },
            { size: 32, count: 24 },
            { size: 40, count: 15 },
            { size: 48, count: 3 },
            { size: 72, count: 2 },
            { size: 80, count: 1 },
            { size: 88, count: 2 },
            { size: 104, count: 1 },
            { size: 112, count: 1 },
            { size: 136, count: 1 },
            { size: 144, count: 2 },
            { size: 152, count: 1 },
            { size: 200, count: 1 },
            { size: 352, count: 1 } ] } ] },
  { callsites: 
     [ { depth: 1,
         name: 'Module._load',
         script: 'module.js',
         script_id: 42,
         start_position: 8228,
         line_number: 285,
         column_number: 24,
         allocations: [] },
       { depth: 2,
         name: 'Module.load',
         script: 'module.js',
         script_id: 42,
         start_position: 9692,
         line_number: 348,
         column_number: 33,
         allocations: [] },
       { depth: 3,
         name: 'Module._extensions..js',
         script: 'module.js',
         script_id: 42,
         start_position: 12077,
         line_number: 424,
         column_number: 37,
         allocations: [] },
       { depth: 4,
         name: 'Module._compile',
         script: 'module.js',
         script_id: 42,
         start_position: 10697,
         line_number: 380,
         column_number: 37,
         allocations: [] },
       { depth: 5,
         name: '',
         script: '/Volumes/d/dev/ns/nsolid/nsolid-node/sample_heap/example.js',
         script_id: 53,
         start_position: 10,
         line_number: 1,
         column_number: 11,
         allocations: [] },
       { depth: 6,
         name: 'mytest',
         script: '/Volumes/d/dev/ns/nsolid/nsolid-node/sample_heap/example.js',
         script_id: 53,
         start_position: 283,
         line_number: 11,
         column_number: 17,
         allocations: 
          [ { size: 16, count: 0 },
            { size: 24, count: 6 },
            { size: 32, count: 440255 },
            { size: 40, count: 6 },
            { size: 48, count: 25856 },
            { size: 56, count: 5 },
            { size: 64, count: 10 },
            { size: 72, count: 1 },
            { size: 88, count: 1 },
            { size: 96, count: 1 },
            { size: 104, count: 0 },
            { size: 112, count: 1 },
            { size: 136, count: 1 },
            { size: 144, count: 712 },
            { size: 152, count: 0 },
            { size: 160, count: 0 },
            { size: 168, count: 1 },
            { size: 200, count: 0 },
            { size: 240, count: 1 },
            { size: 336, count: 713 },
            { size: 360, count: 0 },
            { size: 624, count: 713 },
            { size: 672, count: 0 },
            { size: 808, count: 0 },
            { size: 816, count: 0 },
            { size: 880, count: 0 },
            { size: 912, count: 1 },
            { size: 1000, count: 0 },
            { size: 1008, count: 0 },
            { size: 1056, count: 713 },
            { size: 1096, count: 0 },
            { size: 1128, count: 0 },
            { size: 1136, count: 1 },
            { size: 1704, count: 713 },
            { size: 1808, count: 0 },
            { size: 1832, count: 0 },
            { size: 2672, count: 713 },
            { size: 2832, count: 1 },
            { size: 2880, count: 0 },
            { size: 3424, count: 1 },
            { size: 4128, count: 713 },
            { size: 4368, count: 1 },
            { size: 4448, count: 0 },
            { size: 6312, count: 713 },
            { size: 6672, count: 1 },
            { size: 6800, count: 0 },
            { size: 9584, count: 713 },
            { size: 10128, count: 1 },
            { size: 10328, count: 0 },
            { size: 14496, count: 713 },
            { size: 15624, count: 0 },
            { size: 21864, count: 713 },
            { size: 23568, count: 0 },
            { size: 32912, count: 713 },
            { size: 35480, count: 0 },
            { size: 49488, count: 713 },
            { size: 53336, count: 0 },
            { size: 53352, count: 0 },
            { size: 74352, count: 714 },
            { size: 74360, count: 0 },
            { size: 80120, count: 0 },
            { size: 80160, count: 0 },
            { size: 111648, count: 1020 },
            { size: 111672, count: 1 },
            { size: 120296, count: 1 },
            { size: 120360, count: 2 } ] },
       { depth: 6,
         name: 'v8test',
         script: '/Volumes/d/dev/ns/nsolid/nsolid-node/sample_heap/example.js',
         script_id: 53,
         start_position: 599,
         line_number: 27,
         column_number: 17,
         allocations: 
          [ { size: 32, count: 3 },
            { size: 56, count: 4 },
            { size: 72, count: 2 } ] },
       { depth: 6,
         name: 'visitAllocationProfile',
         script: 'sample_heap.js',
         script_id: 54,
         start_position: 445,
         line_number: 14,
         column_number: 66,
         allocations: 
          [ { size: 24, count: 2 },
            { size: 32, count: 3 },
            { size: 40, count: 6 },
            { size: 48, count: 3 },
            { size: 56, count: 4 },
            { size: 72, count: 4 },
            { size: 416, count: 1 },
            { size: 440, count: 1 },
            { size: 4152, count: 1 } ] } ] },
  { callsites: 
     [ { depth: 1,
         name: 'Module.load',
         script: 'module.js',
         script_id: 42,
         start_position: 9692,
         line_number: 348,
         column_number: 33,
         allocations: [] },
       { depth: 2,
         name: 'Module._extensions..js',
         script: 'module.js',
         script_id: 42,
         start_position: 12077,
         line_number: 424,
         column_number: 37,
         allocations: [] },
       { depth: 3,
         name: 'Module._compile',
         script: 'module.js',
         script_id: 42,
         start_position: 10697,
         line_number: 380,
         column_number: 37,
         allocations: [] },
       { depth: 4,
         name: '',
         script: '/Volumes/d/dev/ns/nsolid/nsolid-node/sample_heap/example.js',
         script_id: 53,
         start_position: 10,
         line_number: 1,
         column_number: 11,
         allocations: [] },
       { depth: 5,
         name: 'v8test',
         script: '/Volumes/d/dev/ns/nsolid/nsolid-node/sample_heap/example.js',
         script_id: 53,
         start_position: 599,
         line_number: 27,
         column_number: 17,
         allocations: [] },
       { depth: 6,
         name: 'foo',
         script: '/Volumes/d/dev/ns/nsolid/nsolid-node/sample_heap/example.js',
         script_id: 53,
         start_position: 638,
         line_number: 29,
         column_number: 22,
         allocations: 
          [ { size: 16, count: 3 },
            { size: 24, count: 4 },
            { size: 32, count: 6 },
            { size: 40, count: 3 },
            { size: 48, count: 3 },
            { size: 56, count: 1 },
            { size: 64, count: 1 },
            { size: 72, count: 1 },
            { size: 136, count: 1 },
            { size: 152, count: 1 },
            { size: 160, count: 1 },
            { size: 176, count: 1 },
            { size: 344, count: 1 },
            { size: 632, count: 1 },
            { size: 1064, count: 1 },
            { size: 1712, count: 1 },
            { size: 2688, count: 1 },
            { size: 4152, count: 1 },
            { size: 6344, count: 1 },
            { size: 9632, count: 1 } ] } ] } ]
```
